### PR TITLE
fixed name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "raygun",
+  "name": "raygun4js",
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
   "version": "1.7.2",


### PR DESCRIPTION
Package name was incorrect. It was using the package name for the Node-specific Raygun project.
