### PR TITLE
Add error message instead of custom data when circular reference detecte...

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -285,8 +285,9 @@
     try {
       JSON.stringify(finalCustomData);
     } catch (e) {
-      finalCustomData = null;
-      log('Raygun4JS: Cannot add custom data; may contain circular reference');
+      var msg = 'Cannot add custom data; may contain circular reference';
+      finalCustomData = JSON.stringify({error: msg});
+      log('Raygun4JS: ' + msg);
     }
 
     var payload = {


### PR DESCRIPTION
Add error message so end user knows why their customData went missing.
