### PR TITLE
an option to ignore Ajax abort errors

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -146,7 +146,7 @@
         (jqXHR.statusText || 'unknown') +' '+
         (ajaxSettings.type || 'unknown') + ' '+
         (truncateURL(ajaxSettings.url) || 'unknown');
-    // ignroe ajax abort if set in the options
+    // ignore ajax abort if set in the options
     if (_ignoreAjaxAbort) {
       if (!jqXHR.getAllResponseHeaders()) {
          return;


### PR DESCRIPTION
We currently have 100's of errors coming from clients aborting ajax calls.
(Leaving the page or generating new calls before the data is loaded)

This fix sets an option for the init function to decide weather to ignore the abort errors or not.

Please review this change and let us know if this can be merged into the next version.

Thanks,
Yaron Shamir
Semaphore Consulting, Australia
