### PR TITLE
Updated processing of _filteredKeys to fix bug

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -310,10 +310,15 @@
                  qs[key] = value;
               }
             } else {
+              var included = true;
               for (i = 0; i < _filteredKeys.length; i++) {
                 if (_filteredKeys[i] === key) {
-                   qs[key] = value;
+                   included = false;
+                   break;
                 }
+              }
+              if (included) {
+                   qs[key] = value;
               }
             }
           } else {


### PR DESCRIPTION
Updated calculating of whether a key should be filtered when iterating through the _filteredKeys array because Array.prototype.indexOf is not available.

Fixes #58
