### PR TITLE
AJAX response data reporting

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -191,7 +191,7 @@
       ajaxErrorMessage: message,
       contentType: ajaxSettings.contentType,
       requestData: ajaxSettings.data ? ajaxSettings.data.slice(0, 10240) : undefined,
-      responseData: jqXHR.responseText });
+      responseData: jqXHR.responseText ? jqXHR.responseText.slice(0, 10240) : undefined });
   }
 
   function log(message, data) {


### PR DESCRIPTION
This update to raygun.js pushes AJAX response data into the error report to provide more context for an AJAX failure. In such an example, I can look at an error report with the following and know I don't need to do further investigation.

```
requestData FirstName=Me&MiddleName=&LastName=Here&Gender=male&Dob=4+September%2C+2016&Email=here%40there.com&Phone=123456789
responseData    {"message":"The request is invalid.","modelState":{"model.Dob":["Date of birth must be in the past."]}}
```
