### PR TITLE
Added option "options.excludedUserAgents"

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -29,6 +29,7 @@ var raygunFactory = function (window, $, undefined) {
       _beforeSendCallback,
       _raygunApiUrl = 'https://api.raygun.io',
       _excludedHostnames = [],
+      _excludedUserAgents = [],
       $document;
 
   if ($) {
@@ -61,6 +62,7 @@ var raygunFactory = function (window, $, undefined) {
         _ignoreAjaxAbort = options.ignoreAjaxAbort || false;
         _disableAnonymousUserTracking = options.disableAnonymousUserTracking || false;
         _excludedHostnames = options.excludedHostnames || false;
+        _excludedUserAgents = options.excludedUserAgents || false;
 
         if (typeof options.wrapAsynchronousCallbacks !== 'undefined') {
           _wrapAsynchronousCallbacks = options.wrapAsynchronousCallbacks;
@@ -488,7 +490,7 @@ var raygunFactory = function (window, $, undefined) {
     }
 
     if (_excludedHostnames instanceof Array) {
-      for(var hostIndex in _excludedHostnames){
+      for(var hostIndex in _excludedHostnames) {
         if(window.location.hostname && window.location.hostname === _excludedHostnames[hostIndex]){
           _private.log('Raygun4JS: cancelling send as error originates from an excluded hostname');
 
@@ -496,6 +498,16 @@ var raygunFactory = function (window, $, undefined) {
         }
       }
     }
+    
+    if (_excludedUserAgents instanceof Array) {
+      for(var userAgentIndex in _excludedUserAgents) {
+        if(navigator.userAgent.toLowerCase().indexOf(_excludedUserAgents[userAgentIndex]) > -1) {
+          _private.log('Raygun4JS: cancelling send as error originates from an excluded user agent');
+          
+          return;
+        }
+      }
+    }    
 
     if (stackTrace.stack && stackTrace.stack.length) {
       forEach(stackTrace.stack, function (i, frame) {


### PR DESCRIPTION
This pull request is related to #97. It adds the option **excludedUserAgents** to give the possibility to exclude error reports from specified user agents. 

Example:

```js
Raygun.init('apikey', {
  excludedUserAgents: ['CasperJS', 'PhantomJS']
}).attach();
```