### PR TITLE
Fix for #116 (Don't stash errors rejected with HTTP 429 in localStorage)

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -704,7 +704,8 @@ var raygunFactory = function (window, $, undefined) {
 
         if (xhr.status === 202) {
           sendSavedErrors();
-        } else if (_enableOfflineSave && xhr.status !== 403 && xhr.status !== 400) {
+        } else if (_enableOfflineSave && xhr.status !== 403 &&
+                   xhr.status !== 400 && xhr.status !== 429) {
           offlineSave(data);
         }
       };


### PR DESCRIPTION
This should fix #116. It might be worth locking down the allowable error codes even further, but I'm not sure which status codes should trigger it.