### PR TITLE
Prevents init overriding withCustomData config

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -55,7 +55,7 @@ var raygunFactory = function (window, $, undefined) {
             _raygunApiKey = key;
             _traceKit.remoteFetching = false;
 
-            if (typeof customdata !== 'undefined') {
+            if (typeof customdata !== 'undefined' && customdata !== null) {
               _customData = customdata;
             }
 


### PR DESCRIPTION
In the V2 API any Custom Data configuration set with:

rg4js('withCustomData', {});

Gets overwritten by the call to init() as null is passed as the 3rd parameter:

      Raygun.init(apiKey, options, null);

The check in init() only looks for undefined.