### PR TITLE
Fix missing stacktrace for syntax error.

### DIFF
--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -107,7 +107,12 @@
 
       errorQueue = window[window['RaygunObject']].q;
       for (var j in errorQueue) {
-        rg.send(errorQueue[j].e, { handler: 'From Raygun4JS snippet global error handler' });
+        var err = errorQueue[j];
+        if (!err.e || !('lineNumber' in err.e) && (!err.e.stack || err.e.stack.split("\n").length < 2)) {
+          window.onerror(err.msg, err.url, err.line, err.col);
+        } else {
+          window.onerror(err.msg, err.url, err.line, err.col, errorQueue[j].e);
+        }
       }
     } else {
       window.onerror = null;

--- a/src/snippet/unminified.js
+++ b/src/snippet/unminified.js
@@ -20,7 +20,7 @@
       }
 
       wind[obj].q = wind[obj].q || [];
-      wind[obj].q.push({e: err});
+      wind[obj].q.push({e: err, msg: msg, url: url, line: line, col: col});
     };
 
 })(window, document, 'script', '//cdn.raygun.io/raygun4js/raygun.min.js', 'rg4js');


### PR DESCRIPTION
Fixes #125

This problem happens when there is syntax error in one of scripts.

The problem is because Chrome and Safari it will NOT add `stack` to error, but will pass extra arguments to `window.onerror` function. While in Firefox error will have extra properties `fileName`, `columnNumber` and `lineNumber`.

Probably my code style is different with existing code, please let me know how to make it align
