### PR TITLE
Changed the message of scriptError

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -567,7 +567,7 @@ var raygunFactory = function (window, $, forBreadcrumbs, undefined) {
             return;
         }
 
-        var scriptError = 'Script error';
+        var scriptError = 'The Tracekit stackTrace is empty, could be a Script Error';
 
         var stack = [],
             qs = {};


### PR DESCRIPTION
scriptError variable seems misleading given it only becomes the message if the stacktrace is empty. If this is the only cases that this happens, we should at least differentiate the message from the standard Script Error thrown by browsers. 

Situations where the Stacktrace can be empty but not a script error: https://github.com/csnover/TraceKit/pull/70