### PR TITLE
Correctly record button text for click event breadcrumbs

### DIFF
--- a/src/raygun.utilities.js
+++ b/src/raygun.utilities.js
@@ -315,7 +315,7 @@ window.raygunUtilityFactory = function (window, Raygun) {
         var text = node.textContent || node.innerText || "";
 
         if (["submit", "button"].indexOf(node.type) !== -1) {
-          text = node.value;
+          text = node.value || text;
         }
 
         text = text.replace(/^\s+|\s+$/g, "");


### PR DESCRIPTION
For some reason the node type of a button is "submit" which currently causes the nodeText utility function to try and retrieve the text via the `value` property. This updates that logic to fall back to `nodeText`/`textContent` if `value` is falsey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4js/269)
<!-- Reviewable:end -->
