### PR TITLE
Fix crash populating breadcrumbs when _breadcrumbs.all() errors

### DIFF
--- a/src/raygun.breadcrumbs.js
+++ b/src/raygun.breadcrumbs.js
@@ -143,12 +143,12 @@ window.raygunBreadcrumbsFactory = function(window, Raygun) {
         for (var i = 0; i < this.breadcrumbs.length; i++) {
             var crumb = this.breadcrumbs[i];
 
-            if (crumb.type === 'request' && !this.logXhrContents) {
-                if (crumb.metadata.responseText) {
+            if (crumb && crumb.type === 'request' && !this.logXhrContents) {
+                if (crumb.metadata && crumb.metadata.responseText) {
                     crumb.metadata.responseText = 'Disabled';
                 }
 
-                if (crumb.metadata.requestText) {
+                if (crumb.metadata && crumb.metadata.requestText) {
                     crumb.metadata.requestText = undefined;
                 }
             }

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -805,7 +805,7 @@ var raygunFactory = function (window, $, undefined) {
 
         if (_breadcrumbs.any()) {
             payload.Details.Breadcrumbs = [];
-            var crumbs = _breadcrumbs.all();
+            var crumbs = _breadcrumbs.all() || [];
 
             crumbs.forEach(function(crumb) {
                 if (crumb.metadata) {


### PR DESCRIPTION
If the `all` method in the Breadcrumbs module encounters an error the error handling function it is wrapped with will return undefined. In raygun.js when we retrieve the breadcrumbs to push them onto the error payload it is assumed that at least an empty array is returned. This attempts to fix any potential processing errors in the `all` method and ensures at least an empty array is used when iterating over the breadcrumbs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4js/275)
<!-- Reviewable:end -->
