### PR TITLE
Add typescript 'types' location to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "name": "MindscapeHQ",
     "email": "hello@raygun.io"
   },
+  "types" : "typescript/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/MindscapeHQ/raygun4js.git"


### PR DESCRIPTION
When the types property is specified like this, users who include the module will not need to include the DefinitelyTyped library ie @types/raygun4js Refers to issue #283 

Fixes #283 