### PR TITLE
Always return a new object when using merge array

### DIFF
--- a/src/raygun.utilities.js
+++ b/src/raygun.utilities.js
@@ -159,7 +159,7 @@ window.raygunUtilityFactory = function(window, Raygun) {
       if (t1 != null) {
         return t0.concat(t1);
       }
-      return t0;
+      return t0.slice(0);
     },
 
     forEach: function(set, func) {


### PR DESCRIPTION
Return clone when using mergeArray. This prevents object mutation bugs, like Unhandled Exception tag being added to subsequent errors. 