### PR TITLE
Fix RUM crash in React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * v2.15.2
   - Include all dist files in npm package instead of just main file
+  - Don't run RUM in React Native to prevent a crash, RUM does not support React Native
 
 * v2.15.1
   - Fix error in Raygun4JS UMD build with raygunNetworkTrackingFactory being undefined

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   },
   "scripts": {
     "test-local": "LOCAL=true node_modules/.bin/wdio wdio.conf.js",
-    "test": "node_modules/.bin/wdio wdio.conf.js",
-    "prepublish": "grunt build"
+    "test": "node_modules/.bin/wdio wdio.conf.js"
   },
   "dependencies": {},
   "keywords": [

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -483,14 +483,18 @@ var raygunFactory = function(window, $, undefined) {
         _rum.attach();
       };
 
-      if (_loadedFrom === 'onLoad') {
-        startRum();
-      } else {
-        if (window.addEventListener) {
-          window.addEventListener('load', startRum);
+      if (!Raygun.Utilities.isReactNative()) {
+        if (_loadedFrom === 'onLoad') {
+          startRum();
         } else {
-          window.attachEvent('onload', startRum);
+          if (window.addEventListener) {
+            window.addEventListener('load', startRum);
+          } else {
+            window.attachEvent('onload', startRum);
+          }
         }
+      } else {
+        Raygun.Utilities.log('Not enabling RUM because Raygun4JS has detected a React Native environment, see #310 on Github');
       }
     }
 


### PR DESCRIPTION
Don't load RUM in React Native environment. It won't work correctly anyway as we don't have access to the requisite browser APIs.

Re #310 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4js/323)
<!-- Reviewable:end -->
