### PR TITLE
Change status code name and fix URL protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* v2.15.3
+  - Change the key for the status code which gets sent to RUM to statusCode to match the API
+  - Prepend the protocol to the URL in the resolveFullUrl function to accommodate URLs without protocols
+
 * v2.15.2
   - Include all dist files in npm package instead of just main file
   - Don't run RUM in React Native to prevent a crash, RUM does not support React Native

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.15.2</version>
+    <version>2.15.3</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -489,7 +489,7 @@ var raygunRumFactory = function(window, $, Raygun) {
 
                 collection.push({
                   url: response.baseUrl,
-                  status: response.status,
+                  statusCode: response.status,
                   timing: { du: response.duration },
                 });
               }
@@ -569,9 +569,9 @@ var raygunRumFactory = function(window, $, Raygun) {
 
       var xhrStatusesForName = this.xhrStatusMap[url];
       if (xhrStatusesForName && xhrStatusesForName.length > 0) {
-        timingData.status = this.xhrStatusMap[url].shift().status;
+        timingData.statusCode = this.xhrStatusMap[url].shift().status;
 
-        log('found status for timing', timingData.status);
+        log('found status for timing', timingData.statusCode);
         if (this.xhrStatusMap[url].length === 0) {
           delete this.xhrStatusMap[url];
         }

--- a/src/raygun.utilities.js
+++ b/src/raygun.utilities.js
@@ -413,6 +413,10 @@ window.raygunUtilityFactory = function(window, Raygun) {
       return window.location.origin;
     },
     resolveFullUrl: function(url) {
+      if(url && url.indexOf('//') === 0) {
+        url = window.location.protocol + url;
+      }
+
       if (url && window.location.pathname && url.indexOf('://') === -1) {
         var origin = this.getOrigin();
 

--- a/tests/specs/v2/rumXhrStatusTracking.js
+++ b/tests/specs/v2/rumXhrStatusTracking.js
@@ -27,17 +27,17 @@ describe("RUM status code tracking", function() {
     var timingPayload = payloadsWithoutRaygunApi(JSON.parse(requestPayloads[2].eventData[0].data));
 
     var expectedPairs = [
-      {url: 'http://localhost:4567/fixtures/v2/foo.html', status: 404, type: 'relative url that does not exist'},
-      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', status: 200, type: 'plain relative url'},
-      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', status: 200, type: 'relative url with query string'},
-      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', status: 200, type: 'absolute url'},
+      {url: 'http://localhost:4567/fixtures/v2/foo.html', statusCode: 404, type: 'relative url that does not exist'},
+      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', statusCode: 200, type: 'plain relative url'},
+      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', statusCode: 200, type: 'relative url with query string'},
+      {url: 'http://localhost:4567/fixtures/v2/rumXhrStatusCodes.html', statusCode: 200, type: 'absolute url'},
     ];
 
     for (var i = 0;i < expectedPairs.length; i++) {
       var payloadUrl = timingPayload[i].url;
-      var payloadStatus = timingPayload[i].status;
+      var payloadStatus = timingPayload[i].statusCode;
       var pairUrl = expectedPairs[i].url;
-      var pairStatus = expectedPairs[i].status;
+      var pairStatus = expectedPairs[i].statusCode;
       var pairType = expectedPairs[i].type;
 
       expect(payloadUrl).toBe(pairUrl, "failed for type: " + pairType);


### PR DESCRIPTION
## Updates

- Change the key for the status code which gets sent to RUM to `statusCode` to match the API
- Prepend the protocol to the URL in the `resolveFullUrl` function to accommodate URLs without protocols