### PR TITLE
fix(network-tracking): catch exceptions when reading body text()

### DIFF
--- a/src/raygun.network-tracking.js
+++ b/src/raygun.network-tracking.js
@@ -192,11 +192,15 @@ window.raygunNetworkTrackingFactory = function(window, Raygun) {
               }
 
               if (ourResponse) {
-                ourResponse.text().then(function(text) {
-                  body = Raygun.Utilities.truncate(text, 500);
+                try {
+                  ourResponse.text().then(function(text) {
+                    body = Raygun.Utilities.truncate(text, 500);
 
+                    executeHandlers();
+                  });
+                } catch(_e) {
                   executeHandlers();
-                });
+                }
               } else {
                 executeHandlers();
               }


### PR DESCRIPTION
On a fetch call, sometimes the body can't be read when calling text().
Wrap the code that tries to do this in a try/catch as it is unessential
code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4js/330)
<!-- Reviewable:end -->
