### PR TITLE
Add option to set clients ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.17.0
+  - Add inital support for users to set the client IP address
+
 * v2.16.1
   - Fix promise rejection errors when trying to retrieve fetch response text in network-tracking module
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ objects (for partial matches). Each should match the hostname or TLD that you wa
 
 `apiEndpoint` - A string URI containing the protocol, domain and port (optional) where all payloads will be sent to. This can be used to proxy payloads to the Raygun API through your own server. When not set this defaults internally to the Raygun API, and for most usages you won't need to set this.
 
+`clientIp` - A string containing the client's IP address. RUM requests will be associated to this IP address when set. Particularally useful when proxying payloads to the Raygun API using the `apiEndpoint` option and maintaining RUM's geographic lookup feature.
+
 `pulseMaxVirtualPageDuration` - The maximum time a virtual page can be considered viewed, in milliseconds (defaults to 30 minutes).
 
 `pulseIgnoreUrlCasing` - Ignore URL casing when sending data to Pulse.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.16.1</version>
+    <version>2.17.0</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -66,6 +66,7 @@ var raygunFactory = function(window, $, undefined) {
     $document,
     _captureUnhandledRejections = true,
     _setCookieAsSecure = false,
+    _clientIp,
     detachPromiseRejectionFunction;
 
   var rand = Math.random();
@@ -143,6 +144,10 @@ var raygunFactory = function(window, $, undefined) {
 
         if (options.from) {
           _loadedFrom = options.from;
+        }
+
+        if(options.clientIp) {
+          _clientIp = options.clientIp;
         }
       }
 
@@ -362,6 +367,11 @@ var raygunFactory = function(window, $, undefined) {
         }
       }
     },
+
+    setClientIp: function(ip) {
+      _clientIp = ip;
+    },
+
     recordBreadcrumb: function() {
       _breadcrumbs.recordBreadcrumb.apply(_breadcrumbs, arguments);
     },
@@ -1019,6 +1029,10 @@ var raygunFactory = function(window, $, undefined) {
     var xhr = createCORSRequest('POST', url, data);
     if (typeof xhr.setRequestHeader === 'function') {
       xhr.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+
+      if(typeof _clientIp !== "undefined") {
+        xhr.setRequestHeader('X-Remote-Address', _clientIp);
+      }
     }
 
     if (typeof _beforeXHRCallback === 'function') {

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -195,6 +195,9 @@
         case 'logContentsOfXhrCalls':
           rg.setBreadcrumbOption('logXhrContents', pair[1]);
           break;
+        case 'clientIp':
+          rg.setClientIp(value);
+          break;
         case 'captureUnhandledRejections':
           captureUnhandledRejections = value;
           break;

--- a/tests/fixtures/common/instrumentXHRs.js
+++ b/tests/fixtures/common/instrumentXHRs.js
@@ -19,6 +19,10 @@
   };
 
   XMLHttpRequest.prototype.getRequestHeader = function() {
+    if(!this.__headers) {
+      this.__headers = {};
+    }
+
     var header = arguments[0];
     return this.__headers[header] || null;
   };

--- a/tests/fixtures/v2/withClientIpSet.html
+++ b/tests/fixtures/v2/withClientIpSet.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Raygun4JS with Client IP</title>
+    <script src="/fixtures/common/instrumentXHRs.js"></script>
+    <script type="text/javascript">
+        !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
+        (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
+        f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
+        h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
+        e:g})}}(window,document,"script","/dist/raygun.js","rg4js");
+    </script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      rg4js('apiKey', 'abcd==');
+      rg4js('enablePulse', true);
+      rg4js('options', {
+        allowInsecureSubmissions: true,
+        debugMode: true,
+        clientIp: '192.168.0.12'
+      });
+    </script>
+
+  </body>
+</html>

--- a/tests/fixtures/v2/withoutClientIpSet.html
+++ b/tests/fixtures/v2/withoutClientIpSet.html
@@ -1,0 +1,26 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Raygun4JS without Client IP</title>
+    <script src="/fixtures/common/instrumentXHRs.js"></script>
+    <script type="text/javascript">
+        !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
+        (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
+        f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
+        h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
+        e:g})}}(window,document,"script","/dist/raygun.js","rg4js");
+    </script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      rg4js('apiKey', 'abcd==');
+      rg4js('enablePulse', true);
+      rg4js('options', {
+        allowInsecureSubmissions: true,
+        debugMode: true,
+      });
+    </script>
+
+  </body>
+</html>

--- a/tests/specs/v2/clientIp.js
+++ b/tests/specs/v2/clientIp.js
@@ -1,0 +1,38 @@
+/* globals describe, beforeEach, it, expect, browser, window */
+
+var _ = require('underscore');
+
+describe("ClientIp", function() {
+
+  it("X-Remote-Address is null when not set", function () {
+    browser.url('http://localhost:4567/fixtures/v2/withoutClientIpSet.html');
+
+    browser.pause(4000);
+
+    var sentXhrs = browser.execute(function () {
+      return window.__sentXHRs;
+    });
+
+    var remoteAddressIsUndefined = _.every(sentXhrs.value, function (req) {
+      return req.clientIp === null;
+    });
+
+    expect(remoteAddressIsUndefined).toBe(true);
+  });
+
+  it("X-Remote-Address is equal to '192.168.0.12'", function () {
+    browser.url('http://localhost:4567/fixtures/v2/withClientIpSet.html');
+
+    browser.pause(4000);
+
+    var sentXhrs = browser.execute(function () {
+      return window.__sentXHRs;
+    });
+
+    var remoteAddressIsSet = _.every(sentXhrs.value, function (req) {
+      return req.clientIp === "192.168.0.12";
+    });
+
+    expect(remoteAddressIsSet).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds a new option to set the clients IP address. This client IP is sent with all requests under the `X-Remote-Address` header. This is useful for those wishing to proxy requests to Raygun (using the `apiEndpoint` option) but also want to maintain existing functionality. 