### PR TITLE
Revert sessionstorage to localstoage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.17.1
+  - Fix regression and use localStorage to persist RUM sessions instead of sessionStorage
+
 * v2.17.0
   - Add inital support for users to set the client IP address
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.17.0</version>
+    <version>2.17.1</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -923,8 +923,8 @@ var raygunRumFactory = function(window, $, Raygun) {
       var lastActivityTimestamp = new Date().toISOString();
       var updatedValue = 'id|' + value + '&timestamp|' + lastActivityTimestamp;
 
-      if(Raygun.Utilities.sessionStorageAvailable()) {
-        sessionStorage.setItem(self.cookieName, updatedValue);
+      if(Raygun.Utilities.localStorageAvailable()) {
+        localStorage.setItem(self.cookieName, updatedValue);
       } else {
         Raygun.Utilities.createCookie(self.cookieName, updatedValue, null, self.setCookieAsSecure);
       }
@@ -932,14 +932,22 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     function getFromStorage() {
       /**
-       * Attempt to get the value from session storage, 
+       * Attempt to get the value from local storage, 
        * If that doesn't contain a value then try from a cookie as previous versions saved it here
        */
       var value; 
 
+      if(Raygun.Utilities.localStorageAvailable()) {
+        value = localStorage.getItem(self.cookieName);
+        if(value !== null) {
+          return value;
+        }
+      }
+
       if(Raygun.Utilities.sessionStorageAvailable()) {
         value = sessionStorage.getItem(self.cookieName);
         if(value !== null) {
+          saveToStorage(value);
           return value;
         }
       }
@@ -947,12 +955,12 @@ var raygunRumFactory = function(window, $, Raygun) {
       value = Raygun.Utilities.readCookie(self.cookieName);
 
       /**
-       * If there was a cookie and sessionStorage is avaliable then  
+       * If there was a cookie and localStorage is avaliable then  
        * clear the cookie as sessionStorage will be the storage mechanism going forward
        */  
-      if(value !== null && Raygun.Utilities.sessionStorageAvailable()) {
+      if(value !== null && Raygun.Utilities.localStorageAvailable()) {
         Raygun.Utilities.clearCookie(self.cookieName);
-        sessionStorage.setItem(self.cookieName, value);
+        localStorage.setItem(self.cookieName, value);
       }
 
       return value;

--- a/tests/specs/common.js
+++ b/tests/specs/common.js
@@ -36,7 +36,7 @@ module.exports = {
   },
   getSessionStorageValue: function(key) {
     return browser.execute(function (name) {
-      return sessionStorage.getItem(name);
+      return localStorage.getItem(name);
     }, key).value;
   },
   setCookieValue: function(key, value) {

--- a/tests/specs/sessions/realUserMonitoring.js
+++ b/tests/specs/sessions/realUserMonitoring.js
@@ -49,7 +49,7 @@ describe("RUM Session Tracking", function() {
     expect(newTimestampIsGreater).toBe(true);
   });
   
-  it("retrieves session id from a cookie and sets it in sessionStorage", function() {
+  it("retrieves session id from a cookie and sets it in localStorage", function() {
     var sessionValue = 'cookieId';
     var timestamp = new Date(new Date() - 60000).toISOString();
     var cookieValue = 'id|' + sessionValue + '&timestamp|' + timestamp;

--- a/tests/specs/sessions/realUserMonitoring.js
+++ b/tests/specs/sessions/realUserMonitoring.js
@@ -13,14 +13,14 @@ describe("RUM Session Tracking", function() {
 
   afterEach(function() {
     browser.execute(function() {
-      sessionStorage.clear();
+      localStorage.clear();
     });
   });
 
   it("persists a session id into storage when one doesn't exist", function() {
     browser.url("http://localhost:4567/fixtures/sessions/rumSession.html");
 
-    var result = common.getSessionStorageValue("raygun4js-sid");
+    var result = common.getLocalStorageValue("raygun4js-sid");
     expect(result).not.toBe(null);
   });
 
@@ -31,12 +31,12 @@ describe("RUM Session Tracking", function() {
       var sessionValue = 'abc123';
       
       var sessionString = 'id|' + sessionValue + '&timestamp|' + timestamp;
-      sessionStorage.setItem('raygun4js-sid', sessionString);
+      localStorage.setItem('raygun4js-sid', sessionString);
     }, oneMinuteAgoTimestamp);
 
     browser.url("http://localhost:4567/fixtures/sessions/rumSession.html");
 
-    var result = common.getSessionStorageValue("raygun4js-sid")
+    var result = common.getLocalStorageValue("raygun4js-sid")
 
     const set = result.split(/[|&]/);
 
@@ -58,7 +58,7 @@ describe("RUM Session Tracking", function() {
 
     browser.url("http://localhost:4567/fixtures/sessions/rumSession.html");
 
-    var result = common.getSessionStorageValue("raygun4js-sid")
+    var result = common.getLocalStorageValue("raygun4js-sid")
 
     const set = result.split(/[|&]/);
 
@@ -75,12 +75,12 @@ describe("RUM Session Tracking", function() {
         var sessionValue = 'expiredId';
         var oneHourAgoTimestamp = new Date(new Date() - 60 * 60000).toISOString();
         var sessionString = 'id|' + sessionValue + '&timestamp|' + oneHourAgoTimestamp;
-        sessionStorage.setItem('raygun4js-sid', sessionString);
+        localStorage.setItem('raygun4js-sid', sessionString);
       });
 
       browser.url("http://localhost:4567/fixtures/sessions/rumSession.html");
 
-      var result = common.getSessionStorageValue("raygun4js-sid")
+      var result = common.getLocalStorageValue("raygun4js-sid")
 
       expect(result.indexOf('id|expiredId')).toBe(-1);
       expect(result.split('&')[0]).not.toBe('id|expiredId');
@@ -88,12 +88,12 @@ describe("RUM Session Tracking", function() {
 
     it("creates a new session id if value stored is null", function() {
       browser.execute(function() {
-        sessionStorage.setItem('raygun4js-sid', null);
+        localStorage.setItem('raygun4js-sid', null);
       });
 
       browser.url("http://localhost:4567/fixtures/sessions/rumSession.html");
 
-      var result = common.getSessionStorageValue("raygun4js-sid")
+      var result = common.getLocalStorageValue("raygun4js-sid")
       expect(result).not.toBe(null);
     });
   });


### PR DESCRIPTION
Reverts using session storage and instead use local storage to persist the session id. This is because new sessions are created when users open the same domain in different tabs which will associate those pages with new calls, when we want them to be associated with the same session. 