### PR TITLE
chore: XHR response tracking log capitalisation

### DIFF
--- a/src/raygun.network-tracking.js
+++ b/src/raygun.network-tracking.js
@@ -105,7 +105,7 @@ window.raygunNetworkTrackingFactory = function(window, Raygun) {
                 body = this.responseText;
               }
 
-              Raygun.Utilities.log('tracking xhr response for', url);
+              Raygun.Utilities.log('Tracking XHR response for', url);
               self.executeHandlers(self.responseHandlers, {
                 status: this.status,
                 requestURL: url,


### PR DESCRIPTION
Since I see this log quite often I'd like to see it with correct capitalisation :slightly_smiling_face: 