### PR TITLE
Disable tracking XHR requests missing from the performance API by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-* v2.17.3
+* v2.18.0
+  - Missing XHR timings are no longer tracked by default. Instead a configuration option exists to enable these via 'captureMissingRequests'
   - Set the maximum duration of missing XHR calls to 5 minutes
   - Add offset timings to missing XHR calls
   - Support for tracking fetch methods which might be referenced locally    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* v2.17.3
+  - Set the maximum duration of missing XHR calls to 5 minutes
+  - Add offset timings to missing XHR calls
+  - Support for tracking fetch methods which might be referenced locally    
+
 * v2.17.2
   - Fixes an issue where the XHR data type was not attached to statusCode calls
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ objects (for partial matches). Each should match the hostname or TLD that you wa
 
 `setCookieAsSecure` - If the cookies are being used (only used on browsers which don't support localStorage or sessionStorage) then they will be created using the `; secure` flag and thus cookies only work on HTTPS.
 
-`captureMissingRequests` - RUM uses the window.performance API to track XHR timing information and (depending on the browser) not all 2XX XHR timings are recorded by this API. This option enables the tracking of these missing XHR's calls by tracking the difference between send & success XHR handlers. This is not enabled by default as the accuracy of these timings is not as good as the 
+`captureMissingRequests` - RUM uses the window.performance API to track XHR timing information and (depending on the browser) not all non-2XX XHR timings are recorded by this API. This option enables the tracking of these missing XHR's calls by tracking the difference between send & success XHR handlers. This is not enabled by default because the accuracy of these timings is not as good as the performance API. 
 
 An example:
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ objects (for partial matches). Each should match the hostname or TLD that you wa
 
 `setCookieAsSecure` - If the cookies are being used (only used on browsers which don't support localStorage or sessionStorage) then they will be created using the `; secure` flag and thus cookies only work on HTTPS.
 
-`captureMissingRequests` - RUM uses the window.performance API to track XHR timing information and (depending on the browser) not all non-2XX XHR timings are recorded by this API. This option enables the tracking of these missing XHR's calls by tracking the difference between send & success XHR handlers. This is not enabled by default because the accuracy of these timings is not as good as the performance API. 
+`captureMissingRequests` - RUM uses the window.performance API to track XHR timing information and (depending on the browser) not all non-2XX XHR timings are recorded by this API. This option enables the tracking of these missing XHR's calls by tracking the difference between send & success XHR handlers. This is not enabled by default due these timings being as accurate as the performance API. 
 
 An example:
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ objects (for partial matches). Each should match the hostname or TLD that you wa
 
 `setCookieAsSecure` - If the cookies are being used (only used on browsers which don't support localStorage or sessionStorage) then they will be created using the `; secure` flag and thus cookies only work on HTTPS.
 
+`captureMissingRequests` - RUM uses the window.performance API to track XHR timing information and (depending on the browser) not all 2XX XHR timings are recorded by this API. This option enables the tracking of these missing XHR's calls by tracking the difference between send & success XHR handlers. This is not enabled by default as the accuracy of these timings is not as good as the 
+
 An example:
 
 ```javascript
@@ -219,7 +221,8 @@ rg4js('options', {
   pulseMaxVirtualPageDuration: 1800000,
   pulseIgnoreUrlCasing: false,
   captureUnhandledRejections: true,
-  setCookieAsSecure: false
+  setCookieAsSecure: false,
+  captureMissingRequests: false
 });
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.17.3",
+  "version": "2.18.0",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.17.3",
+  "version": "2.18.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.17.2</version>
+    <version>2.17.3</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.17.3</version>
+    <version>2.18.0</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -371,7 +371,11 @@ var raygunFactory = function(window, $, undefined) {
     setClientIp: function(ip) {
       _clientIp = ip;
     },
-
+    captureMissingRequests: function(val) {
+      if (Raygun.RealUserMonitoring !== undefined && _rum) {
+        _rum.captureMissingRequests(val);
+      }
+    },
     recordBreadcrumb: function() {
       _breadcrumbs.recordBreadcrumb.apply(_breadcrumbs, arguments);
     },

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -67,6 +67,7 @@ var raygunFactory = function(window, $, undefined) {
     _captureUnhandledRejections = true,
     _setCookieAsSecure = false,
     _clientIp,
+    _captureMissingRequests = false,
     detachPromiseRejectionFunction;
 
   var rand = Math.random();
@@ -116,6 +117,7 @@ var raygunFactory = function(window, $, undefined) {
         _pulseIgnoreUrlCasing = options.pulseIgnoreUrlCasing || false;
         _pulseCustomLoadTimeEnabled = options.pulseCustomLoadTimeEnabled || false;
         _setCookieAsSecure = options.setCookieAsSecure || false;
+        _captureMissingRequests = options.captureMissingRequests || false;
 
         if (options.apiUrl) {
           _raygunApiUrl = options.apiUrl;
@@ -148,7 +150,7 @@ var raygunFactory = function(window, $, undefined) {
 
         if(options.clientIp) {
           _clientIp = options.clientIp;
-        }
+        }        
       }
 
       ensureUser();
@@ -492,7 +494,8 @@ var raygunFactory = function(window, $, undefined) {
           _pulseIgnoreUrlCasing,
           _pulseCustomLoadTimeEnabled,
           _beforeSendRumCallback,
-          _setCookieAsSecure
+          _setCookieAsSecure,
+          _captureMissingRequests
         );
         _rum.attach();
       };

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -198,6 +198,9 @@
         case 'clientIp':
           rg.setClientIp(value);
           break;
+        case 'captureMissingRequests': 
+          rg.captureMissingRequests(value);
+          break;
         case 'captureUnhandledRejections':
           captureUnhandledRejections = value;
           break;

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -574,7 +574,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       }
 
       return url;
-    };
+    }.bind(this);;
 
     /**
      * Stops sending through timing information if a XHR request has been made by the response handler hasn't been fired. 
@@ -586,7 +586,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       var request = this.xhrRequestMap[url];
 
       return request && request.length > 0;
-    };
+    }.bind(this);
 
     var getSecondaryTimingData = function(timing, offset) {
       var url = getTimingUrl(timing);

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -836,13 +836,13 @@ var raygunRumFactory = function(window, $, Raygun) {
     // ================================================================================
 
     function xhrRequestHandler(request) {
-      if(!this.xhrRequestMap[request]) {
+      if(!this.xhrRequestMap[request.baseUrl]) {
         this.xhrRequestMap[request.baseUrl] = [];
       }
 
       log('adding request to xhr request map', request);
 
-      this.xhrRequestMap[request].push(request);
+      this.xhrRequestMap[request.baseUrl].push(request);
     }
 
     function xhrResponseHandler(response) {

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -468,7 +468,7 @@ var raygunRumFactory = function(window, $, Raygun) {
             collection.push(getSecondaryTimingData(resources[i], offset));
           }
         }
-        
+
         self.offset = i;
 
         if(this._captureMissingRequests) {
@@ -578,7 +578,7 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     /**
      * Stops sending through timing information if a XHR request has been made by the response handler hasn't been fired. 
-     * This is to prevent issues where multiple timings for the same asset can be sen. 
+     * This is to prevent issues where multiple timings for the same asset can be sent. 
      * Once for the performance timing and another for the missing request (if the captureMissingRequests option is enabled)
      */
     var waitingForResourceToFinishLoading = function(timing) {

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -574,6 +574,11 @@ var raygunRumFactory = function(window, $, Raygun) {
       return url;
     };
 
+    /**
+     * Stops sending through timing information if a XHR request has been made by the response handler hasn't been fired. 
+     * This is to prevent issues where multiple timings for the same asset can be sen. 
+     * Once for the performance timing and another for the missing request (if the captureMissingRequests option is enabled)
+     */
     var waitingForResourceToFinishLoading = function(timing) {
       var url = getTimingUrl(timing);
       var request = this.xhrRequestMap[url];

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -108,6 +108,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       }
 
       Raygun.NetworkTracking.on('request', xhrRequestHandler.bind(this));
+      Raygun.NetworkTracking.on('error', xhrErrorHandler.bind(this));
       Raygun.NetworkTracking.on('response', xhrResponseHandler.bind(this));
     };
 
@@ -843,6 +844,15 @@ var raygunRumFactory = function(window, $, Raygun) {
       log('adding request to xhr request map', request);
 
       this.xhrRequestMap[request.baseUrl].push(request);
+    }
+
+    function xhrErrorHandler(response) {
+      var request = this.xhrRequestMap[response.baseUrl];
+      
+      if(request && request.length > 0) {
+        this.xhrRequestMap[response.baseUrl].shift();
+        log('request errored out', response);
+      }
     }
 
     function xhrResponseHandler(response) {

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -848,6 +848,10 @@ var raygunRumFactory = function(window, $, Raygun) {
     // =                                                                              =
     // ================================================================================
 
+    /**
+     * Add to the requestMap. This marks the request as being in "flight" 
+     * and stops collecting metrics until this request has completed. 
+     */
     function xhrRequestHandler(request) {
       if(!this.xhrRequestMap[request.baseUrl]) {
         this.xhrRequestMap[request.baseUrl] = [];
@@ -858,6 +862,9 @@ var raygunRumFactory = function(window, $, Raygun) {
       this.xhrRequestMap[request.baseUrl].push(request);
     }
     
+    /**
+     * Removes the request from the requestMap so that metric collection can be resumed. 
+     */
     function xhrErrorHandler(response) {
       var request = this.xhrRequestMap[response.baseUrl];
 
@@ -867,6 +874,13 @@ var raygunRumFactory = function(window, $, Raygun) {
       }	      
     }
 
+    /**
+     * Removes the asset from the requestMap if found and adds the response to the 
+     * statusMap so that the status code can be associated with the request. 
+     * 
+     * If the 'captureMissingRequests' option is enabled and the timing metric is missing 
+     * the duration will also be used to create a new XHR timing.    
+     */
     function xhrResponseHandler(response) {
       var request = this.xhrRequestMap[response.baseUrl];
 

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -58,7 +58,7 @@ var raygunRumFactory = function(window, $, Raygun) {
     this.heartBeatInterval = null;
     this.heartBeatIntervalTime = 30000;
     this.offset = 0;
-    this.captureMissingRequests = captureMissingRequests || false;
+    this._captureMissingRequests = false;
 
     this.queuedItems = [];
     this.maxQueueItemsSent = 50;
@@ -179,6 +179,10 @@ var raygunRumFactory = function(window, $, Raygun) {
           sendQueuedPerformancePayloads();
         }
       }
+    };
+
+    this.captureMissingRequests = function(val) {
+      this._captureMissingRequests = val;
     };
 
     // ================================================================================
@@ -460,7 +464,7 @@ var raygunRumFactory = function(window, $, Raygun) {
           }
         }
 
-        if(this.captureMissingRequests) {
+        if(this._captureMissingRequests) {
           addMissingWrtData(collection, offset);
         } else {
           clearMissingWrtData();

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -459,15 +459,17 @@ var raygunRumFactory = function(window, $, Raygun) {
       try {
         var offset = fromVirtualPage ? 0 : window.performance.timing.navigationStart;
         var resources = window.performance.getEntries();
+        var i;
 
-        for (var i = self.offset; i < resources.length; i++) {
+        for (i = self.offset; i < resources.length; i++) {
           if(!forceSend && waitingForResourceToFinishLoading(resources[i])) {
             break;
           } else if (!shouldIgnoreResource(resources[i])) {
             collection.push(getSecondaryTimingData(resources[i], offset));
           }
-          self.offset = i + 1;
         }
+        
+        self.offset = i;
 
         if(this._captureMissingRequests) {
           addMissingWrtData(collection, offset);

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -574,7 +574,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       }
 
       return url;
-    }.bind(this);;
+    }.bind(this);
 
     /**
      * Stops sending through timing information if a XHR request has been made by the response handler hasn't been fired. 

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -25,7 +25,8 @@ var raygunRumFactory = function(window, $, Raygun) {
     ignoreUrlCasing,
     customTimingsEnabled,
     beforeSendCb,
-    setCookieAsSecure
+    setCookieAsSecure,
+    captureMissingRequests
   ) {
     var self = this;
     var _private = {};
@@ -57,7 +58,7 @@ var raygunRumFactory = function(window, $, Raygun) {
     this.heartBeatInterval = null;
     this.heartBeatIntervalTime = 30000;
     this.offset = 0;
-    this._captureMissingRequests = false;
+    this._captureMissingRequests = captureMissingRequests || false;
 
     this.queuedItems = [];
     this.maxQueueItemsSent = 50;

--- a/tests/fixtures/v2/rumFetchPolyfillStatusCodes.html
+++ b/tests/fixtures/v2/rumFetchPolyfillStatusCodes.html
@@ -21,6 +21,7 @@
       rg4js('options', {
         allowInsecureSubmissions: true,
         debugMode: true,
+        captureMissingRequests: true
       });
 
       setTimeout(function () {

--- a/tests/fixtures/v2/rumFetchStatusCodes.html
+++ b/tests/fixtures/v2/rumFetchStatusCodes.html
@@ -18,7 +18,8 @@
       rg4js('enablePulse', true);
       rg4js('options', {
         allowInsecureSubmissions: true,
-        debugMode: true
+        debugMode: true,
+        captureMissingRequests: true
       });
 
       setTimeout(function () {

--- a/tests/fixtures/v2/rumReferencedFetchWithFetchSnippet.html
+++ b/tests/fixtures/v2/rumReferencedFetchWithFetchSnippet.html
@@ -56,7 +56,8 @@
       rg4js('enablePulse', true);
       rg4js('options', {
         allowInsecureSubmissions: true,
-        debugMode: true
+        debugMode: true,
+        captureMissingRequests: true
       });
 
       setTimeout(function () {

--- a/tests/fixtures/v2/rumXhrStatusCodes.html
+++ b/tests/fixtures/v2/rumXhrStatusCodes.html
@@ -22,7 +22,8 @@
       rg4js('enablePulse', true);
       rg4js('options', {
         allowInsecureSubmissions: true,
-        debugMode: true
+        debugMode: true,
+        captureMissingRequests: true
       });
 
       setTimeout(function () {


### PR DESCRIPTION
Updates how we track XHR & Fetch requests which are missing from the window.performance API and when they are sent to Raygun. These will no longer be sent by default, instead you can configure the `captureMissingRequests` option to enable this setting.

The reason behind this is that the timings for these requests are not as accurate as the performance API (as the functionality relies on listening to event listeners, which can be delayed) and we only have the duration to go on.

Included updates: 
- When collecting timing information any XHR timings which we detect are still 'in-flight' (have had a request but not a response) will be delayed from being sent (until the next collection). This is due to a edge case where the timings can be recorded twice.
