### PR TITLE
[RUM SUP-21] [BUG] First paint captured incorrectly - Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.18.2
+  - Fixes an issue with first-paint being calculated incorrectly for Edge/IE browsers
+
 * v2.18.1
   - Fixes an issue with how the network tracking util integrates with the fetch snippet 
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.18.1</version>
+    <version>2.18.2</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -690,7 +690,9 @@ var raygunRumFactory = function(window, $, Raygun) {
     /**
      * Adds first-paint and first-contentful-paint timings onto the main page timing. 
      * The performance API is used as it's a more standard method only supported in Chrome.
-     * The `msFirstPaint` is used for Edge/IE browsers.
+     * The `msFirstPaint` is used for Edge/IE browsers and returns a Unix timestamp.
+     * We calculate the difference between 'msFirstPaint' and 'connectStart' to get first-paint
+     * for Edge/IE.
      */
     function addPaintTimings(data) {
       if(!performanceEntryExists('getEntriesByName', 'function')) {
@@ -702,7 +704,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       if(firstPaint.length > 0 && firstPaint[0].startTime > 0) {
         data.fp = firstPaint[0].startTime.toFixed(2); 
       } else if(window.performance.timing && !!window.performance.timing.msFirstPaint) {
-        data.fp = window.performance.timing.msFirstPaint.toFixed(2);
+        data.fp = (window.performance.timing.msFirstPaint - window.performance.timing.connectStart);
       }
 
       var firstContentfulPaint = window.performance.getEntriesByName('first-contentful-paint');

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -690,9 +690,8 @@ var raygunRumFactory = function(window, $, Raygun) {
     /**
      * Adds first-paint and first-contentful-paint timings onto the main page timing. 
      * The performance API is used as it's a more standard method only supported in Chrome.
-     * The `msFirstPaint` is used for Edge/IE browsers and returns a Unix timestamp.
-     * We calculate the difference between 'msFirstPaint' and 'connectStart' to get first-paint
-     * for Edge/IE.
+     * `msFirstPaint` is used for Edge/IE browsers and returns a Unix timestamp. We calculate 
+     * the difference between 'msFirstPaint' and 'connectStart' to get first-paint for Edge/IE.
      */
     function addPaintTimings(data) {
       if(!performanceEntryExists('getEntriesByName', 'function')) {

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -703,7 +703,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       if(firstPaint.length > 0 && firstPaint[0].startTime > 0) {
         data.fp = firstPaint[0].startTime.toFixed(2); 
       } else if(window.performance.timing && !!window.performance.timing.msFirstPaint) {
-        data.fp = (window.performance.timing.msFirstPaint - window.performance.timing.connectStart);
+        data.fp = (window.performance.timing.msFirstPaint - window.performance.timing.fetchStart).toFixed(2);
       }
 
       var firstContentfulPaint = window.performance.getEntriesByName('first-contentful-paint');


### PR DESCRIPTION
Description:

FP was being calculated incorrectly for IE/Edge browsers. This PR implements a fix for this by calculating the difference between `ms-firstPaint` and `fetchStart`.