### PR TITLE
Update API endpoint from api.raygun.io to api.raygun.com

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -56,7 +56,7 @@ var raygunFactory = function(window, $, undefined) {
     _groupingKeyCallback,
     _beforeXHRCallback,
     _afterSendCallback,
-    _raygunApiUrl = 'https://api.raygun.io',
+    _raygunApiUrl = 'https://api.raygun.com',
     _excludedHostnames = null,
     _excludedUserAgents = null,
     _filterScope = 'customData',

--- a/tests/specs/v1/eventsXhr.js
+++ b/tests/specs/v1/eventsXhr.js
@@ -2,7 +2,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe("XHR functional tests for /events with V1", function() {
 

--- a/tests/specs/v1/payloadManualSendTests.js
+++ b/tests/specs/v1/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V1 manual send", function() {
 

--- a/tests/specs/v1/payloadUnhandledErrorTests.js
+++ b/tests/specs/v1/payloadUnhandledErrorTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V1 automatic unhandled error sending", function() {
 

--- a/tests/specs/v2/eventsXhr.js
+++ b/tests/specs/v2/eventsXhr.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe("XHR functional tests for /events with V2", function() {
 

--- a/tests/specs/v2/onBeforeSendRUM.js
+++ b/tests/specs/v2/onBeforeSendRUM.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe('onBeforeSendRUM callback', function() {
   it('lets you modify the payload before sending', function() {

--- a/tests/specs/v2/payloadManualSendTests.js
+++ b/tests/specs/v2/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V2 manual send", function() {
 

--- a/tests/specs/v2/payloadSyntaxError.js
+++ b/tests/specs/v2/payloadSyntaxError.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V2 syntax error caught with the Snippet", function() {
 


### PR DESCRIPTION
This PR changes the default endpoint from api.raygun.io to api.raygun.com as .com is now the recommended endpoint.