### PR TITLE
Use navigator.sendBeacon when document is unloading

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -1116,6 +1116,12 @@ var raygunFactory = function(window, $, undefined) {
       xhr.setRequestHeader('Content-type', 'application/json;charset=UTF-8');
     }
 
+    // When the document is unloading, all inflight XHR requests will be canceled. Try sendBeacon instead.
+    if (window.__raygunIsUnloading && navigator.sendBeacon) {
+      navigator.sendBeacon(url, data);
+      return;
+    }
+
     xhr.send(data);
   }
 

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -91,6 +91,7 @@ var raygunRumFactory = function(window, $, Raygun) {
       }.bind(_private);
 
       var unloadHandler = function() {
+        window.__raygunIsUnloading = true;
         sendChildAssets(true);
         sendQueuedItems();
       }.bind(_private);


### PR DESCRIPTION
This PR fixes the bug first reported in 2016 in issue #186 

When using `trackEvent` `pageView` (tracking page views in single page apps) telemetry for the last page is never sent. This is because any XHR requests sent in the [beforeunload event handler](https://github.com/MindscapeHQ/raygun4js/blob/master/src/raygun.rum.js#L107) is cancelled before it has a chance to open the connection.

We can fix this by using [navigator.sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) if available.

The only difference on Chrome is the standard request headers contain `Sec-Fetch-Mode: cors` but when using sendBeacon this changes to `Sec-Fetch-Mode: no-cors`. Since this is an experimental header it has no effect currently. I don't forsee any future issues as the server sets `Access-Control-Allow-Origin: *` and the content is sent as `Content-Type: text/plain;charset=UTF-8`.

This PR is really very important to us as the first few pages of our app are introduction/configuration. The user is expected to spend most of their time on the last page. Telemetry from this page the the most important. It seems to me this is the case for most apps I have worked on. 