### PR TITLE
Ignore navigation entryTypes and fix breadcrumb XHR requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* v2.18.4
+  - Fixes an issue where we record the "navigation" entryTypes as cached child assets
+  - Fixes an issue with `setAutoBreadcrumbsXHRIgnoredHosts` not being applied when requests are opened
+
 * v2.18.3
   - Use navigator.sendBeacon when avaliable to send the last request as XHR requests can be cancelled
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.io plugin for JavaScript",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.18.3</version>
+    <version>2.18.4</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.breadcrumbs.js
+++ b/src/raygun.breadcrumbs.js
@@ -432,7 +432,7 @@ window.raygunBreadcrumbsFactory = function(window, Raygun) {
     var self = this;
 
     var requestHandler = self.wrapWithHandler(function(request) {
-      if (urlMatchesIgnoredHosts(request.url, self.xhrIgnoredHosts)) {
+      if (urlMatchesIgnoredHosts(request.requestURL, self.xhrIgnoredHosts)) {
         return;
       }
 

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -919,7 +919,7 @@ var raygunRumFactory = function(window, $, Raygun) {
     function shouldIgnoreResource(resource) {
       var name = resource.name.split('?')[0];
 
-      return shouldIgnoreResourceByName(name) || resource.entryType === "paint";
+      return shouldIgnoreResourceByName(name) || resource.entryType === "paint" || resource.entryType === "navigation";
     }
 
     function shouldIgnoreResourceByName(name) {

--- a/tests/fixtures/breadcrumbs/automatic.xhr.html
+++ b/tests/fixtures/breadcrumbs/automatic.xhr.html
@@ -19,6 +19,7 @@
     <script type="text/javascript">
       rg4js('apiKey', 'abcdef==');
       rg4js('enableCrashReporting', true);
+      rg4js('enablePulse', true);
       rg4js('options', {
         allowInsecureSubmissions: true,
         debugMode: true

--- a/tests/specs/breadcrumbs/automatic.xhr.js
+++ b/tests/specs/breadcrumbs/automatic.xhr.js
@@ -1,5 +1,6 @@
 /* globals describe, beforeEach, it, expect, browser, window */
 
+var _ = require('underscore');
 var common = require("../common");
 
 describe("XHR tracking", function() {
@@ -44,6 +45,16 @@ describe("XHR tracking", function() {
     var breadcrumbs = common.getBreadcrumbs();
 
     expect(breadcrumbs[3].CustomData.requestURL).toBe("http://localhost:4567/fixtures/breadcrumbs/automatic.xhr.html");
+  });
+
+  it('does not record requests to raygun domains', function() {
+    var breadcrumbs = common.getBreadcrumbs();
+
+    var doesNotContainRaygun = _.every(breadcrumbs, function (crumb) {
+      return crumb.CustomData.requestURL.indexOf('raygun') === -1
+    });
+
+    expect(doesNotContainRaygun).toBe(true);
   });
 
   it("does not log bodies when logXhrContents is false", function() {


### PR DESCRIPTION
This PR introduces a couple of bug fixes: 

- Ignore navigation types with a 'entryType' of 'navigation'. Previously these were being counted as 'cached child assets'
- Fixes a breadcrumb issue where the `setAutoBreadcrumbsXHRIgnoredHosts` values would be ignored when requests are being opened. Meaning excess breadcrumb values were being logged