### PR TITLE
Add end session functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.19.0
+  - Add manual end session functionality to public API
+
 * v2.18.4
   - Fixes an issue where we record the "navigation" entryTypes as cached child assets
   - Fixes an issue with `setAutoBreadcrumbsXHRIgnoredHosts` not being applied when requests are opened

--- a/README.md
+++ b/README.md
@@ -582,6 +582,16 @@ This will be transmitted with each message. A count of unique users will appear 
 
 You can now pass in empty strings (or false to `isAnonymous`) to reset the current user for login/logout scenarios.
 
+### Ending a session
+
+To end a user's current session:
+
+```javascript
+rg4js('endSession');
+```
+
+This will end the session for a user and start a new one.
+
 ### Version filtering
 
 You can set a version for your app by calling:

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -128,6 +128,9 @@
         case 'groupingKey':
           rg.groupingKey(value);
           break;
+        case 'endSession':
+          rg.endSession();
+          break;
 
         // Delayed execution functions
         case 'send':

--- a/src/raygun.rum.js
+++ b/src/raygun.rum.js
@@ -155,12 +155,10 @@ var raygunRumFactory = function(window, $, Raygun) {
     };
 
     this.endSession = function() {
-      sendItemImmediately({
-        sessionId: self.sessionId,
-        requestId: self.requestId,
-        timestamp: new Date().toISOString(),
-        type: 'session_end',
-      });
+      self.sessionId = randomKey(32);
+      saveToStorage(self.sessionId);
+
+      sendNewSessionStart();
     };
 
     this.sendCustomTimings = function(customTimings) {


### PR DESCRIPTION
This PR updates the `endSession` function to be properly included in the public API and trigger a new session start when called instead of sending an outdated payload to Raygun.

I have also added this to the README