### PR TITLE
Mobile browser bug fix: Send data with the pagehide instead of unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * v2.20.1
-  - Fixes an issue where mobile browsers (most notability mobile safari) won't send data when the page is unloading  
+  - Fixes an issue where some browsers (most notably Mobile Safari) won't send data when the page is being transitioned away from
 
 * v2.20.0
   - Adds new custom timings support which enables Custom Timings to work with SPA's and regardless of page loads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.20.1
+  - Fixes an issue where mobile browsers (most notability mobile safari) won't send data when the page is unloading  
+
 * v2.20.0
   - Adds new custom timings support which enables Custom Timings to work with SPA's and regardless of page loads
   - Adds an option `automaticPerformanceCustomTimings` for tracking performance.measure calls as custom timings 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.20.0</version>
+    <version>2.20.1</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -459,9 +459,6 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     function addPerformanceTimingsToQueue(performanceData, forceSend) {
       if(self.stopCollectingMetrics === false) {
-        /**
-         * Only collect performance timings when the 
-         */
         self.queuedPerformanceTimings = self.queuedPerformanceTimings.concat(performanceData);
         sendQueuedPerformancePayloads(forceSend);
       }

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -165,7 +165,7 @@ var raygunRumFactory = function(window, $, Raygun) {
         this.virtualPage = path;
       }
 
-      resumeCollectingMetricsFromNow();
+      resumeCollectingMetrics();
       processVirtualPageTimingsInQueue();
       sendPerformance(false);
     };
@@ -918,7 +918,7 @@ var raygunRumFactory = function(window, $, Raygun) {
     // =                                                                              =
     // ================================================================================
 
-    function resumeCollectingMetricsFromNow() {
+    function resumeCollectingMetrics() {
       if(self.stopCollectingMetrics) {
         self.offset = window.performance.getEntries().length;
         self.stopCollectingMetrics = false;

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -919,8 +919,10 @@ var raygunRumFactory = function(window, $, Raygun) {
     // ================================================================================
 
     function resumeCollectingMetricsFromNow() {
-      self.offset = window.performance.getEntries().length;
-      self.stopCollectingMetrics = false;
+      if(self.stopCollectingMetrics) {
+        self.offset = window.performance.getEntries().length;
+        self.stopCollectingMetrics = false;
+      }
     }
 
     /**

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -165,6 +165,7 @@ var raygunRumFactory = function(window, $, Raygun) {
         this.virtualPage = path;
       }
 
+      resumeCollectingMetricsFromNow();
       processVirtualPageTimingsInQueue();
       sendPerformance(false);
     };
@@ -916,6 +917,11 @@ var raygunRumFactory = function(window, $, Raygun) {
     // =                                  Utilities                                   =
     // =                                                                              =
     // ================================================================================
+
+    function resumeCollectingMetricsFromNow() {
+      self.offset = window.performance.getEntries().length;
+      self.stopCollectingMetrics = false;
+    }
 
     /**
      * Returns true if the resources entry type is set to "measure"

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -899,8 +899,9 @@ var raygunRumFactory = function(window, $, Raygun) {
       var stringifiedPayload = JSON.stringify(payload);
 
       /** 
-       * Use the navigator.sendBeacon method instead of a XHR request.
-       * This the document is unloading, all inflight XHR requests will be canceled
+       * Use the navigator.sendBeacon method instead of a XHR requests when transmitting data
+       * This occurs mostly when the document is about to be discarded or hidden as 
+       * all inflight XHR requests either will be or can be canceled.
        */ 
       if (self.sendUsingNavigatorBeacon && navigator.sendBeacon) {
         navigator.sendBeacon(url, stringifiedPayload);


### PR DESCRIPTION
Fixes an issue where mobile browsers won't send data in when they don't fire the 'beforeunload' event handler. The main browser this affects is Mobile Safari, but this can impact other browsers as well. 