### PR TITLE
Fallback for duration values of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.20.3
+  - Adds a fallback for calculating the duration for timing entries which have a `.duration` value of zero. This fixes a issue where Safari reports `fetch` calls as having a duration of zero.   
+
 * v2.20.2
   - Fixes an issue with ionic-cordova errors not reporting due to the stack-trace being null. Thanks @nirajrajbhandari for identifying and fixing the problem 
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.20.2</version>
+    <version>2.20.3</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -771,7 +771,7 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     function getSecondaryEncodedTimingData(timing, offset) {
       var data = {
-        du: maxFiveMinutes(timing.duration).toFixed(2),
+        du: maxFiveMinutes(getTimingDuration(timing)).toFixed(2),
         t: getSecondaryTimingType(timing),
         a: offset + timing.fetchStart,
       };

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -919,6 +919,13 @@ var raygunRumFactory = function(window, $, Raygun) {
     // ================================================================================
 
     function getTimingDuration(timing) {
+      /**
+       * Safari timing entries (predominantly 'fetch' types) can have a 
+       * duration value of 0. 
+       * 
+       * This utility fallsback to using the responseEnd - startTime when 
+       * that is the case.
+       */
       var duration = timing.duration;
 
       if(duration !== 0) {

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -918,6 +918,17 @@ var raygunRumFactory = function(window, $, Raygun) {
     // =                                                                              =
     // ================================================================================
 
+    function getTimingDuration(timing) {
+      var duration = timing.duration;
+
+      if(duration !== 0) {
+        return duration;
+      }
+
+      return timing.responseEnd - timing.startTime;
+    }
+    this.Utilities["getTimingDuration"] = getTimingDuration;
+
     function resumeCollectingMetrics() {
       if(self.stopCollectingMetrics) {
         self.offset = window.performance.getEntries().length;

--- a/src/raygun.rum/rum.spec.js
+++ b/src/raygun.rum/rum.spec.js
@@ -103,4 +103,26 @@ describe("raygun.rum", () => {
             });
         });
     });
+
+    describe("getTimingDuration", () => {
+        it('returns the duration when it is not 0', () => {
+            const resource = {
+                name: 'test-resource',
+                startTime: 1000,
+                responseEnd: 2000,
+                duration: 500,
+            };
+            expect(utils.getTimingDuration(resource)).toEqual(500);
+        });
+
+        it('returns startTime - responseEnd when the duration is 0', () => {
+            const resource = {
+                name: 'test-resource',
+                startTime: 1200,
+                responseEnd: 2000,
+                duration: 0,
+            };
+            expect(utils.getTimingDuration(resource)).toEqual(800);
+        });
+    });
 });


### PR DESCRIPTION
Creates a new utility method for retrieving the duration value on performance timing entries. 

When the duration value is not `0` we return that value. When it is zero we attempt to calculate the duration from the `responseEnd - startTime`, which is how [the `duration` value is suppose to work anyhow](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/duration). 

This resolves an issue in Safari where timings resulting from `fetch` calls will have a `duration` value of 0, when the `responseEnd` and `startTime` have valid entries.