### PR TITLE
Replace unhandled rejection error message

### DIFF
--- a/src/raygun.js
+++ b/src/raygun.js
@@ -451,8 +451,9 @@ var raygunFactory = function(window, $, undefined) {
       error = event.reason.error;
     }
     if (!error) {
-      error = event;
+      error = 'Unhandled promise rejection';
     }
+
     _publicRaygunFunctions.send(error, null, ['UnhandledPromiseRejection']);
   }
 

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -451,7 +451,9 @@ var raygunFactory = function(window, $, undefined) {
       error = event.reason.error;
     }
     if (!error) {
-      error = 'Unhandled promise rejection';
+      error = new Error('Unhandled promise rejection');
+      // Clear the stacktrace, as we don't want the error to appear to come from raygun4js
+      error.stack = null;
     }
 
     _publicRaygunFunctions.send(error, null, ['UnhandledPromiseRejection']);

--- a/tests/fixtures/v2/unhandledPromiseRejectionWithNoReason.html
+++ b/tests/fixtures/v2/unhandledPromiseRejectionWithNoReason.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Raygun4JS with V2 API</title>
+  <script src="/fixtures/common/instrumentXHRs.js"></script>
+  <script type="text/javascript">
+    !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
+      (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
+      f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
+      h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
+        e:g})}}(window,document,"script","/dist/raygun.js","rg4js");
+  </script>
+</head>
+<body>
+<script type="text/javascript">
+  rg4js('apiKey', 'abcdef==');
+  rg4js('enableCrashReporting', true);
+  rg4js('options', {
+    allowInsecureSubmissions: true,
+    captureUnhandledRejections: true
+  });
+
+  window.supportsOnunhandledrejection = false;
+
+  if ('onunhandledrejection' in window) {
+    window.supportsOnunhandledrejection = true;
+    var someVariable = 42;
+
+    setTimeout(function timeoutHandler() {
+      new Promise(function promiseHandler(resolve, reject) {
+        if (someVariable !== 42) {
+          resolve(someVariable);
+        } else {
+          reject();
+        }
+      });
+    }, 200);
+  }
+</script>
+</body>
+</html>

--- a/tests/specs/v2/unhandledPromiseRejectionTests.js
+++ b/tests/specs/v2/unhandledPromiseRejectionTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-describe("Unhandled promise rejection", function() {
+fdescribe("Unhandled promise rejection", function() {
     // Tests
 
     it('sends error on unhandled promise rejection', function() {
@@ -22,5 +22,30 @@ describe("Unhandled promise rejection", function() {
 
             expect(unhandledPromise).toBe(true);
         }
+    });
+
+    describe('with no reason provided for rejection', function() {
+        it('sends an error with a relevant message and no stacktrace data', function() {
+            browser.url('http://localhost:4567/fixtures/v2/unhandledPromiseRejectionWithNoReason.html');
+            browser.pause(1000);
+
+            var supportsUnHandledRejections = browser.execute(function() {
+                return window.supportsOnunhandledrejection;
+            });
+
+            if (supportsUnHandledRejections) {
+                browser.pause(10000);
+
+                var requestPayloads = browser.execute(function () {
+                    return window.__requestPayloads;
+                });
+
+                var errorPayload = requestPayloads[0].Details.Error;
+
+                expect(errorPayload.Message).toEqual('Unhandled promise rejection');
+                expect(errorPayload.StackTrace[0].LineNumber).toBeNull();
+                expect(errorPayload.StackTrace[0].ColumnNumber).toBeNull();
+            }
+        });
     });
 });

--- a/tests/specs/v2/unhandledPromiseRejectionTests.js
+++ b/tests/specs/v2/unhandledPromiseRejectionTests.js
@@ -43,6 +43,7 @@ describe("Unhandled promise rejection", function() {
                 var errorPayload = requestPayloads[0].Details.Error;
 
                 expect(errorPayload.Message).toEqual('Unhandled promise rejection');
+                expect(errorPayload.StackTrace.length).toEqual(1);
                 expect(errorPayload.StackTrace[0].LineNumber).toBeNull();
                 expect(errorPayload.StackTrace[0].ColumnNumber).toBeNull();
             }

--- a/tests/specs/v2/unhandledPromiseRejectionTests.js
+++ b/tests/specs/v2/unhandledPromiseRejectionTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-fdescribe("Unhandled promise rejection", function() {
+describe("Unhandled promise rejection", function() {
     // Tests
 
     it('sends error on unhandled promise rejection', function() {


### PR DESCRIPTION
## Overview

Make it easier to distinguish unhandled promise rejection errors from standard script errors by specifying the error message to be "Unhandled promise rejection".

### Updates

- Set the `error` value to a new Error object with a null stacktrace if no reason or detail is defined when an unhandled rejection event occurs.

## Screenshots

<img width="1385" alt="Screen Shot 2020-10-21 at 8 44 13 PM" src="https://user-images.githubusercontent.com/3280759/96688927-381ca180-13de-11eb-92c9-ab22d3ff0c42.png">
