### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,7 +430,7 @@
   - Fixed the need to call attach() (if only using manual sending)
 
 * v1.3.1
-  - Added user tracking and version tracking functionality
+  - Added user tracking/Customers and version tracking functionality
 
 * v1.3.0
   - Updated to latest TraceKit

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ Only `identifier` or the first parameter is required. This method takes addition
 setUser: function (user, isAnonymous, email, fullName, firstName, uuid)
 ```
 
-`user|identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using Customers.
+`user|identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using [Customers](https://raygun.com/documentation/product-guides/customers/).
 
 `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
 
@@ -615,7 +615,7 @@ setUser: function (user, isAnonymous, email, fullName, firstName, uuid)
 
 `uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
 
-This will be transmitted with each message. A count of unique users will appear on the dashboard in the individual error view. If you provide an email address, the user's Gravatar will be displayed (if they have one). This method is optional; if it is not called no Customers will be performed. Note that if the user context changes (such as in an SPA), you should call this method again to update it.
+This will be transmitted with each message. A count of unique users will appear on the dashboard in the individual error view. If you provide an email address, the user's Gravatar will be displayed (if they have one). This method is optional; if it is not called, the [Customers](https://raygun.com/documentation/product-guides/customers/) feature is disabled. Note that if the user context changes (such as in an SPA), you should call this method again to update it.
 
 #### Resetting the user
 

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ rg4js('send', {
 
 As above for custom data, `withTags` can now also accept a callback function. This will be called when the provider is about to send, to construct the tags. The function you pass to `withTags` should return an array (ideally of strings/Numbers/Dates).
 
-### Affected user tracking
+### Customers
 
 By default Raygun4JS assigns a unique anonymous ID for the current user. This is stored in local storage and will default back to using a cookie if local storage is not supported. You can remove the ID from storage by calling:
 
@@ -603,7 +603,7 @@ Only `identifier` or the first parameter is required. This method takes addition
 setUser: function (user, isAnonymous, email, fullName, firstName, uuid)
 ```
 
-`user|identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using user tracking.
+`user|identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using Customers.
 
 `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
 
@@ -615,7 +615,7 @@ setUser: function (user, isAnonymous, email, fullName, firstName, uuid)
 
 `uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
 
-This will be transmitted with each message. A count of unique users will appear on the dashboard in the individual error view. If you provide an email address, the user's Gravatar will be displayed (if they have one). This method is optional; if it is not called no user tracking will be performed. Note that if the user context changes (such as in an SPA), you should call this method again to update it.
+This will be transmitted with each message. A count of unique users will appear on the dashboard in the individual error view. If you provide an email address, the user's Gravatar will be displayed (if they have one). This method is optional; if it is not called no Customers will be performed. Note that if the user context changes (such as in an SPA), you should call this method again to update it.
 
 #### Resetting the user
 

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -477,7 +477,7 @@ var raygunFactory = function(window, $, undefined) {
 
   // The final initializing logic is provided as a callback due to async storage methods for user data in React Native
   // The common case executes it immediately due to that data being provided by the cookie synchronously
-  // The case when Affected User Tracking is enabled calls this function when the code sets the user data
+  // The case when Customers is enabled calls this function when the code sets the user data
   function bootRaygun() {
     if (_providerState === ProviderStates.READY) {
       return;


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers'

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code needs to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG`
👉 Update code comment within `raygun.js`

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'User Tracking'

### Checklist ✔️ 
- [x] Builds pass
- [x] Reviewed by another developer
- [x] Code is written to standards