### PR TITLE
[RUM-661]  Core web vitals - Data formatting

### DIFF
--- a/src/raygun.rum/core-web-vitals.js
+++ b/src/raygun.rum/core-web-vitals.js
@@ -13,9 +13,19 @@
 
 function raygunCoreWebVitalFactory(window) {
     var WebVitalTimingType = "w";
-
-    var CoreWebVitals = function(){};
     var queueTimings = null;
+
+    var CoreWebVitals = function(){
+        this.cleanWebVitalData = function (event) {
+            var res = event;
+
+            if(res.value && res.value.toFixed) {
+                res.value = res.value.toFixed(3);
+            }
+        
+            return res;
+        };
+    };
 
     CoreWebVitals.prototype.attach = function(queueHandler) {
         queueTimings = queueHandler;
@@ -28,6 +38,10 @@ function raygunCoreWebVitalFactory(window) {
     };
 
     CoreWebVitals.prototype.handler = function(event) {
+        if(event.value && event.value.toFixed) {
+            event.value = event.value.toFixed(3);
+        }
+
         var webVitalEvent = {
             url: event.name,
             timing: {
@@ -35,7 +49,7 @@ function raygunCoreWebVitalFactory(window) {
                 du: event.value
             }
         };
-
+        
         queueTimings(webVitalEvent);
     };
 

--- a/src/raygun.rum/core-web-vitals.spec.js
+++ b/src/raygun.rum/core-web-vitals.spec.js
@@ -1,6 +1,6 @@
 /*jshint esversion: 6 */
 
-var cwvfactory = require('./core-web-vitals');
+require('./core-web-vitals');
 
 describe("core-web-vitals", () => {
     let CoreWebVitals = window.raygunCoreWebVitalFactory({ webVitals: null }), queue = [];
@@ -18,5 +18,15 @@ describe("core-web-vitals", () => {
                 }
             });
         });
-    })
+        
+    });
+
+    describe("event reports long metric value", () => {
+        CoreWebVitals.handler({ name: "FID", value: "0.14589" });
+
+        it('value is rounded to 3dp', () => {
+            var res = queue.pop();
+            expect(res.timing.du).toBe("0.146");
+        });
+    });
 });


### PR DESCRIPTION
This PR ensures that all Core Web Vital metric values are reported back to Raygun as 3dp values, to match how our other timings are being formatted.

### Changes:
- Added formatting logic to payload creation method.
- Added a spec to account for the formatting.