### PR TITLE
Enable Core Web Vital tracking by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ _Note: navigator.sendBeacon is used to send RUM payloads when a page is unloadin
 
 `automaticPerformanceCustomTimings` - When enabled Raygun4JS will track each `window.performance.measure` call as a custom timing entry. This enables developers to use a more native API for tracking performance timings. More information about `performance.measure` can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).
 
-`trackCoreWebVitals` - When enabled Raygun4JS will automatically track and report Core Web Vitals.
+`trackCoreWebVitals` - When enabled, Raygun4JS will automatically track and report Core Web Vitals. This is enabled by default.
 
 An example raygun4js configuration:
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ _Note: navigator.sendBeacon is used to send RUM payloads when a page is unloadin
 
 `automaticPerformanceCustomTimings` - When enabled Raygun4JS will track each `window.performance.measure` call as a custom timing entry. This enables developers to use a more native API for tracking performance timings. More information about `performance.measure` can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).
 
+`trackCoreWebVitals` - When enabled Raygun4JS will automatically track and report Core Web Vitals.
+
 An example raygun4js configuration:
 
 ```javascript

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -41,7 +41,7 @@ var raygunFactory = function(window, $, undefined) {
     _disablePulse = true,
     _wrapAsynchronousCallbacks = false,
     _automaticPerformanceCustomTimings = false,
-    _trackCoreWebVitals = false,
+    _trackCoreWebVitals = true,
     _customData = {},
     _tags = [],
     _user,
@@ -122,7 +122,7 @@ var raygunFactory = function(window, $, undefined) {
         _setCookieAsSecure = options.setCookieAsSecure || false;
         _captureMissingRequests = options.captureMissingRequests || false;
         _automaticPerformanceCustomTimings = options.automaticPerformanceCustomTimings || false;
-        _trackCoreWebVitals = options.trackCoreWebVitals || false;
+        _trackCoreWebVitals = options.trackCoreWebVitals || true;
 
         if (options.apiUrl) {
           _raygunApiUrl = options.apiUrl;


### PR DESCRIPTION
This PR will enable Core Web Vital tracking by default, with the option to opt out, so that Raygun is able to report on these new metrics.

Changes made:
- Set default of the `trackCoreWebVitals` option to true.
- Added the option to the readme.
-