### PR TITLE
Non-browser environment fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.22.2
+- Fixes an issue where raygun4js attempts to access the document on non-browser environments. Also ensures that the Core Web Vitals scripts are not initialized for these environments.
+
 * v2.22.1
 - Fixes a compatability issue with the `web-vitals` vendor script and RequireJS.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/src/raygun.rum/core-web-vitals.js
+++ b/src/raygun.rum/core-web-vitals.js
@@ -30,7 +30,7 @@ function raygunCoreWebVitalFactory(window) {
     CoreWebVitals.prototype.attach = function(queueHandler) {
         queueTimings = queueHandler;
 
-        if(window.webVitals) {
+        if(typeof window !== 'undefined' && window.webVitals) {
             if(window.webVitals.getLCP) {
                 window.webVitals.getLCP(this.handler);
             }

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -1,5 +1,9 @@
 (function () {
 
+    if(typeof document === 'undefined') {
+      return;
+    }
+
     /*
      * Copyright 2020 Google LLC
      *

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -1,5 +1,5 @@
 (function () {
-
+    // This ensures that we do not initilize Core Web Vitals for non-browser environments
     if(typeof document === 'undefined') {
       return;
     }

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -2,6 +2,9 @@
  * This comes from the google web-vital repository, base only script @ https://github.com/GoogleChrome/web-vitals
  */
 (function () {
+    if(typeof document === 'undefined') {
+      return;
+    }
 
     /*
      * Copyright 2020 Google LLC
@@ -289,7 +292,7 @@
         // best we can do until an API is available to support querying past
         // visibilityState.
         {
-          firstHiddenTime = self.webVitals.firstHiddenTime;
+          firstHiddenTime = window.webVitals ? window.webVitals.firstHiddenTime : initHiddenTime();
 
           if (firstHiddenTime === Infinity) {
             trackChanges();

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -549,7 +549,8 @@
       afterLoad(function () {
         try {
           // Use the NavigationTiming L2 entry if available.
-          var navigationEntry = performance.getEntriesByType('navigation')[0] || getNavigationEntryFromPerformanceTiming();
+          var navTimings = performance.getEntriesByType('navigation');
+          var navigationEntry;  !!navTimings ? navTimings[0] : getNavigationEntryFromPerformanceTiming();
           metric.value = metric.delta = navigationEntry.responseStart;
           metric.entries = [navigationEntry];
           onReport(metric);

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -2,6 +2,7 @@
  * This comes from the google web-vital repository, base only script @ https://github.com/GoogleChrome/web-vitals
  */
 (function () {
+    // This ensures that we do not initilize Core Web Vitals for non-browser environments
     if(typeof document === 'undefined') {
       return;
     }
@@ -292,7 +293,7 @@
         // best we can do until an API is available to support querying past
         // visibilityState.
         {
-          firstHiddenTime = window.webVitals ? window.webVitals.firstHiddenTime : initHiddenTime();
+          firstHiddenTime = !!self.webVitals ? self.webVitals.firstHiddenTime : initHiddenTime();
 
           if (firstHiddenTime === Infinity) {
             trackChanges();

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -550,7 +550,7 @@
         try {
           // Use the NavigationTiming L2 entry if available.
           var navTimings = performance.getEntriesByType('navigation');
-          var navigationEntry;  !!navTimings ? navTimings[0] : getNavigationEntryFromPerformanceTiming();
+          var navigationEntry = !!navTimings ? navTimings[0] : getNavigationEntryFromPerformanceTiming();
           metric.value = metric.delta = navigationEntry.responseStart;
           metric.entries = [navigationEntry];
           onReport(metric);


### PR DESCRIPTION
This PR aims to address an issue around Core Web Vitals being initiated for non-browser environments. Fixes #397.

Changes made:
- Ensure window exists before attempting to access the `webVitals` attribute.
- Don't init the web vital scripts when the document does not exist as this means that core web vitals cannot be tracked.