### PR TITLE
Fix xhr status map memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.22.3
+- Fixes an issue where the heartbeat was not clearing the `xhrStatusMap` array due to `this` referring to the window object
+
 * v2.22.2
 - Fixes an issue where raygun4js attempts to access the document on non-browser environments. Also ensures that the Core Web Vitals scripts are not initialized for these environments.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -257,7 +257,7 @@ var raygunRumFactory = function(window, $, Raygun) {
         sendChildAssets();
         sendQueuedItems();
         
-        this.xhrStatusMap = {};
+        self.xhrStatusMap = {};
       }, self.heartBeatIntervalTime); // 30 seconds between heartbeats
     }
 


### PR DESCRIPTION
This PR fixes an issue where the heartbeat was not clearing the xhrStatusMap array due to `this` referring to the window object