### PR TITLE
Bump chromedriver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@wdio/spec-reporter": "^6.1.5",
     "@wdio/static-server-service": "^6.0.16",
     "@wdio/sync": "^6.1.8",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^90.0.0",
     "cross-env": "^7.0.2",
     "grunt": "^1.1.0",
     "grunt-contrib-clean": "^2.0.0",


### PR DESCRIPTION
This PR bumps up the chromedriver version to fix a build issue where we are expecting Chrome 90.x.x