### PR TITLE
Add a bundle that excludes the web-vitals vendor scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.22.4
+- Add a new script bundle that doesn't include the web-vitals vendor script
+
 * v2.22.3
 - Fixes an issue where the heartbeat was not clearing the `xhrStatusMap` array due to `this` referring to the window object
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,9 +22,61 @@ module.exports = function(grunt) {
       },
       dist: {
         files: {
-          'dist/raygun.js': ['tracekit/tracekit.js', 'src/raygun.tracekit.jquery.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js'],
-          'dist/raygun.vanilla.js': ['tracekit/tracekit.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js'],
-          'dist/raygun.umd.js': ['src/umd.intro.js', 'tracekit/tracekit.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.tracekit.jquery.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js', 'src/umd.outro.js']
+          'dist/raygun.js': [
+            'tracekit/tracekit.js',
+            'src/raygun.tracekit.jquery.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js'
+          ],
+          'dist/raygun.vanilla.js': [
+            'tracekit/tracekit.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js'
+          ],
+          'dist/raygun.umd.js': [
+            'src/umd.intro.js',
+            'tracekit/tracekit.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.tracekit.jquery.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js',
+            'src/umd.outro.js'
+          ],
+          'dist/raygun.nowebvitals.js': [
+            'tracekit/tracekit.js',
+            'src/raygun.tracekit.jquery.js',
+            'src/polyfills.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js'
+          ],
         }
       }
     },
@@ -37,7 +89,8 @@ module.exports = function(grunt) {
         files: {
           'dist/raygun.min.js': ['dist/raygun.js'],
           'dist/raygun.vanilla.min.js': ['dist/raygun.vanilla.js'],
-          'dist/raygun.umd.min.js': ['dist/raygun.umd.js']
+          'dist/raygun.umd.min.js': ['dist/raygun.umd.js'],
+          'dist/raygun.nowebvitals.min.js': ['dist/raygun.nowebvitals.js'],
         }
       },
       snippet:{

--- a/README.md
+++ b/README.md
@@ -97,10 +97,14 @@ Download the [production version][min] or the [development version][max]. You ca
 the jQuery hooks if you are not using jQuery or you wish to provide your own hooks. Get this as a
 [production version][min.vanilla] or [development version][max.vanilla].
 
+The standard bundle includes the [web-vitals](https://github.com/GoogleChrome/web-vitals) base and polyfill scripts for automatically tracking Core Web Vitals metrics. If you prefer to add these yourself, there is a separate bundle that does not include the vendor scripts. This is available as a [production version][min.nowebvitals] or [development version][max.nowebvitals].
+
 [min]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.min.js
 [max]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.js
 [min.vanilla]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.vanilla.min.js
 [max.vanilla]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.vanilla.js
+[min.nowebvitals]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.nowebvitals.min.js
+[max.nowebvitals]: https://raw.github.com/MindscapeHQ/raygun4js/master/dist/raygun.nowebvitals.js
 
 ## Usage
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.22.0",
+  "version": "2.22.4",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.22.0</version>
+    <version>2.22.4</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>


### PR DESCRIPTION
## Overview

Developers may want to include the [web-vitals](https://github.com/GoogleChrome/web-vitals) base and polyfill scripts themselves due to environmental reasons* or to have better control over how the polyfill script is loaded (see the [How to use the polyfill](https://github.com/GoogleChrome/web-vitals#how-to-use-the-polyfill) section for more details).

*There is a use of [Set and WeakSet](https://github.com/GoogleChrome/web-vitals/blob/cfe7536dc8f13e3cbbbf48436328f52399dd6725/src/lib/finalMetrics.ts#L21) in the library that can cause issues when trying to support legacy browsers (e.g. older than IE11).

## Updates

- Add a new bundle that excludes the web-vitals vendor scripts in the Gruntfile
- Update the readme with links to the new bundle