### PR TITLE
Wrap the sendBeacon call to suppress errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.22.5
+- Fixes an issue where `navigator.sendBeacon` errors were not being handled gracefully.
+
 * v2.22.4
 - Upgrade the web-vitals vendor library to v2.1.0.
 - Fixes an issue where Core Web Vital timings were being queued behind virtual page timings.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.22.4</version>
+    <version>2.22.5</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -911,15 +911,22 @@ var raygunRumFactory = function(window, $, Raygun) {
 
       var stringifiedPayload = JSON.stringify(payload);
 
-      /** 
+      /**
        * Use the navigator.sendBeacon method instead of a XHR requests when transmitting data
-       * This occurs mostly when the document is about to be discarded or hidden as 
+       * This occurs mostly when the document is about to be discarded or hidden as
        * all inflight XHR requests either will be or can be canceled.
-       */ 
+       */
       if (self.sendUsingNavigatorBeacon && navigator.sendBeacon) {
-        navigator.sendBeacon(url, stringifiedPayload);
+        try {
+          navigator.sendBeacon(url, stringifiedPayload);
+        } catch (e) {
+          log(e, {
+            url: url,
+            payload: stringifiedPayload
+          });
+        }
         return;
-      } 
+      }
 
       makePostCorsRequest(url, stringifiedPayload, successCallback, errorCallback);
     }


### PR DESCRIPTION
## Overview

The `navigator.sendBeacon` function can throw an 'Illegal invocation' error in [certain cases](https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch). This change suppresses any errors, but logs out the error with details if debugMode has been enabled.

### Updates

- Wrap the `navigator.sendBeacon` function call with a try-catch, log out the error