### PR TITLE
Send core web vital timing metrics immediately

### DIFF
--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -104,7 +104,7 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     this.attach = function() {
       if(this.trackCoreWebVitals) {
-        Raygun.CoreWebVitals.attach(addPerformanceTimingsToQueue);
+        Raygun.CoreWebVitals.attach(sendCoreWebVitalTimings);
       }
 
       getSessionId(function(isNewSession) {
@@ -475,6 +475,11 @@ var raygunRumFactory = function(window, $, Raygun) {
         self.queuedPerformanceTimings = self.queuedPerformanceTimings.concat(performanceData);
         sendQueuedPerformancePayloads(forceSend);
       }
+    }
+
+    function sendCoreWebVitalTimings(performanceData) {
+      // Core web vital timing metrics need to be sent to the API immediately, if they are queued then they may not be sent if a virtual page timing event occurs before they are tracked
+      sendItemImmediately(createTimingPayload([performanceData]));
     }
 
     // ================================================================================


### PR DESCRIPTION
[APL-37](https://raygun.atlassian.net/browse/APL-37): Release granular customer data for CWV

## Description:
CWV metrics are being added to the queue when they are captured, and when virtual page timings are added to the queue, they block CWV metrics from being sent. By sending them immediately instead of adding them to the queue, they will always be sent and won't be disrupted by virtual pages.

## Test plan:
...

### Author to check:
- [ ] Builds pass 
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written

### Reviewer to check:
- [ ] Change has been tested on Beta
- [ ] Code is written to standards
- [ ] Appropriate tests have been written
Send core web vital timing metrics immediately instead of adding to them to the queue