### PR TITLE
Upgrade web-vitals vendor scripts to version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.22.4
+- Upgrade the web-vitals vendor library to v2.1.0
+
 * v2.22.3
 - Fixes an issue where the heartbeat was not clearing the `xhrStatusMap` array due to `this` referring to the window object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * v2.22.4
-- Upgrade the web-vitals vendor library to v2.1.0
+- Upgrade the web-vitals vendor library to v2.1.0.
+- Fixes an issue where Core Web Vital timings were being queued behind virtual page timings.
 
 * v2.22.3
 - Fixes an issue where the heartbeat was not clearing the `xhrStatusMap` array due to `this` referring to the window object

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.22.0",
+  "version": "2.22.4",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.22.0</version>
+    <version>2.22.4</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -104,7 +104,7 @@ var raygunRumFactory = function(window, $, Raygun) {
 
     this.attach = function() {
       if(this.trackCoreWebVitals) {
-        Raygun.CoreWebVitals.attach(addPerformanceTimingsToQueue);
+        Raygun.CoreWebVitals.attach(sendCoreWebVitalTimings);
       }
 
       getSessionId(function(isNewSession) {
@@ -475,6 +475,11 @@ var raygunRumFactory = function(window, $, Raygun) {
         self.queuedPerformanceTimings = self.queuedPerformanceTimings.concat(performanceData);
         sendQueuedPerformancePayloads(forceSend);
       }
+    }
+
+    function sendCoreWebVitalTimings(performanceData) {
+      // Core web vital timing metrics need to be sent to the API immediately, if they are queued then they may not be sent if a virtual page timing event occurs before they are tracked
+      sendItemImmediately(createTimingPayload([performanceData]));
     }
 
     // ================================================================================

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -4,7 +4,7 @@
  */
 
 (function() {
-  // This ensures that we do not initialize Core Web Vitals for non-browser environments
+  // Raygun: This ensures that we do not initialize Core Web Vitals for non-browser environments
   if (typeof document === 'undefined') {
     return;
   }

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -1,232 +1,105 @@
-(function () {
-    // This ensures that we do not initilize Core Web Vitals for non-browser environments
-    if(typeof document === 'undefined') {
-      return;
-    }
+/**
+ * web-vitals v2.1.0 polyfill
+ */
+(function() {
+  'use strict';
 
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var firstInputEvent;
-    var firstInputDelay;
-    var firstInputTimeStamp;
-    var callbacks;
-    var listenerOpts = {
-      passive: true,
-      capture: true
-    };
-    var startTimeStamp = new Date();
-    /**
-     * Accepts a callback to be invoked once the first input delay and event
-     * are known.
-     */
+  // This ensures that we do not initialize Core Web Vitals for non-browser environments
+  if(typeof document === 'undefined') {
+    return;
+  }
 
-    var firstInputPolyfill = function firstInputPolyfill(onFirstInput) {
-      callbacks.push(onFirstInput);
+  var firstInputEvent;
+  var firstInputDelay;
+  var firstInputTimeStamp;
+  var callbacks;
+  var listenerOpts = { passive: true, capture: true };
+  var startTimeStamp = new Date;
+  var firstInputPolyfill = function firstInputPolyfill(onFirstInput) {
+    callbacks.push(onFirstInput);
+    reportFirstInputDelayIfRecordedAndValid();
+  };
+  var resetFirstInputPolyfill = function resetFirstInputPolyfill() {
+    callbacks = [];
+    firstInputDelay = -1;
+    firstInputEvent = null;
+    eachEventType(addEventListener);
+  };
+  var recordFirstInputDelay = function recordFirstInputDelay(delay, event) {
+    if (!firstInputEvent) {
+      firstInputEvent = event;
+      firstInputDelay = delay;
+      firstInputTimeStamp = new Date;
+      eachEventType(removeEventListener);
       reportFirstInputDelayIfRecordedAndValid();
-    };
-    var resetFirstInputPolyfill = function resetFirstInputPolyfill() {
+    }
+  };
+  var reportFirstInputDelayIfRecordedAndValid = function reportFirstInputDelayIfRecordedAndValid() {
+    if (firstInputDelay >= 0 && firstInputDelay < firstInputTimeStamp - startTimeStamp) {
+      var entry = {
+        entryType: 'first-input',
+        name: firstInputEvent.type,
+        target: firstInputEvent.target,
+        cancelable: firstInputEvent.cancelable,
+        startTime: firstInputEvent.timeStamp,
+        processingStart: firstInputEvent.timeStamp + firstInputDelay,
+      };
+      callbacks.forEach((function(callback) {
+        callback(entry);
+      }));
       callbacks = [];
-      firstInputDelay = -1;
-      firstInputEvent = null;
-      eachEventType(addEventListener);
+    }
+  };
+  var onPointerDown = function onPointerDown(delay, event) {
+    var onPointerUp = function onPointerUp() {
+      recordFirstInputDelay(delay, event);
+      removePointerEventListeners();
     };
-    /**
-     * Records the first input delay and event, so subsequent events can be
-     * ignored. All added event listeners are then removed.
-     */
-
-    var recordFirstInputDelay = function recordFirstInputDelay(delay, event) {
-      if (!firstInputEvent) {
-        firstInputEvent = event;
-        firstInputDelay = delay;
-        firstInputTimeStamp = new Date();
-        eachEventType(removeEventListener);
-        reportFirstInputDelayIfRecordedAndValid();
-      }
+    var onPointerCancel = function onPointerCancel() {
+      removePointerEventListeners();
     };
-    /**
-     * Reports the first input delay and event (if they're recorded and valid)
-     * by running the array of callback functions.
-     */
-
-
-    var reportFirstInputDelayIfRecordedAndValid = function reportFirstInputDelayIfRecordedAndValid() {
-      // In some cases the recorded delay is clearly wrong, e.g. it's negative
-      // or it's larger than the delta between now and initialization.
-      // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
-      // - https://github.com/GoogleChromeLabs/first-input-delay/issues/6
-      // - https://github.com/GoogleChromeLabs/first-input-delay/issues/7
-      if (firstInputDelay >= 0 && // @ts-ignore (subtracting two dates always returns a number)
-      firstInputDelay < firstInputTimeStamp - startTimeStamp) {
-        var entry = {
-          entryType: 'first-input',
-          name: firstInputEvent.type,
-          target: firstInputEvent.target,
-          cancelable: firstInputEvent.cancelable,
-          startTime: firstInputEvent.timeStamp,
-          processingStart: firstInputEvent.timeStamp + firstInputDelay
-        };
-        callbacks.forEach(function (callback) {
-          callback(entry);
-        });
-        callbacks = [];
-      }
+    var removePointerEventListeners = function removePointerEventListeners() {
+      removeEventListener('pointerup', onPointerUp, listenerOpts);
+      removeEventListener('pointercancel', onPointerCancel, listenerOpts);
     };
-    /**
-     * Handles pointer down events, which are a special case.
-     * Pointer events can trigger main or compositor thread behavior.
-     * We differentiate these cases based on whether or not we see a
-     * 'pointercancel' event, which are fired when we scroll. If we're scrolling
-     * we don't need to report input delay since FID excludes scrolling and
-     * pinch/zooming.
-     */
-
-
-    var onPointerDown = function onPointerDown(delay, event) {
-      /**
-       * Responds to 'pointerup' events and records a delay. If a pointer up event
-       * is the next event after a pointerdown event, then it's not a scroll or
-       * a pinch/zoom.
-       */
-      var onPointerUp = function onPointerUp() {
+    addEventListener('pointerup', onPointerUp, listenerOpts);
+    addEventListener('pointercancel', onPointerCancel, listenerOpts);
+  };
+  var onInput = function onInput(event) {
+    if (event.cancelable) {
+      var isEpochTime = event.timeStamp > 1e12;
+      var now = isEpochTime ? new Date : performance.now();
+      var delay = now - event.timeStamp;
+      if (event.type == 'pointerdown') {
+        onPointerDown(delay, event);
+      } else {
         recordFirstInputDelay(delay, event);
-        removePointerEventListeners();
-      };
-      /**
-       * Responds to 'pointercancel' events and removes pointer listeners.
-       * If a 'pointercancel' is the next event to fire after a pointerdown event,
-       * it means this is a scroll or pinch/zoom interaction.
-       */
-
-
-      var onPointerCancel = function onPointerCancel() {
-        removePointerEventListeners();
-      };
-      /**
-       * Removes added pointer event listeners.
-       */
-
-
-      var removePointerEventListeners = function removePointerEventListeners() {
-        removeEventListener('pointerup', onPointerUp, listenerOpts);
-        removeEventListener('pointercancel', onPointerCancel, listenerOpts);
-      };
-
-      addEventListener('pointerup', onPointerUp, listenerOpts);
-      addEventListener('pointercancel', onPointerCancel, listenerOpts);
-    };
-    /**
-     * Handles all input events and records the time between when the event
-     * was received by the operating system and when it's JavaScript listeners
-     * were able to run.
-     */
-
-
-    var onInput = function onInput(event) {
-      // Only count cancelable events, which should trigger behavior
-      // important to the user.
-      if (event.cancelable) {
-        // In some browsers `event.timeStamp` returns a `DOMTimeStamp` value
-        // (epoch time) instead of the newer `DOMHighResTimeStamp`
-        // (document-origin time). To check for that we assume any timestamp
-        // greater than 1 trillion is a `DOMTimeStamp`, and compare it using
-        // the `Date` object rather than `performance.now()`.
-        // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
-        var isEpochTime = event.timeStamp > 1e12;
-        var now = isEpochTime ? new Date() : performance.now(); // Input delay is the delta between when the system received the event
-        // (e.g. event.timeStamp) and when it could run the callback (e.g. `now`).
-
-        var delay = now - event.timeStamp;
-
-        if (event.type == 'pointerdown') {
-          onPointerDown(delay, event);
-        } else {
-          recordFirstInputDelay(delay, event);
-        }
       }
-    };
-    /**
-     * Invokes the passed callback const for =  each event type with t =>he
-     * `onInput` const and =  `listenerOpts =>`.
-     */
-
-
-    var eachEventType = function eachEventType(callback) {
-      var eventTypes = ['mousedown', 'keydown', 'touchstart', 'pointerdown'];
-      eventTypes.forEach(function (type) {
-        return callback(type, onInput, listenerOpts);
-      });
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var firstHiddenTime = document.visibilityState === 'hidden' ? 0 : Infinity;
-
-    var onVisibilityChange = function onVisibilityChange(event) {
-      if (document.visibilityState === 'hidden') {
-        firstHiddenTime = event.timeStamp;
-        removeEventListener('visibilitychange', onVisibilityChange, true);
-      }
-    }; // Note: do not add event listeners unconditionally (outside of polyfills).
-
-
-    addEventListener('visibilitychange', onVisibilityChange, true);
-    var getFirstHiddenTime = function getFirstHiddenTime() {
-      return firstHiddenTime;
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    resetFirstInputPolyfill();
-    self.webVitals = {
-      firstInputPolyfill: firstInputPolyfill,
-      resetFirstInputPolyfill: resetFirstInputPolyfill,
-
-      // TODO: in v2 this should just be `getFirstHiddenTime()`,
-      // but in v1 it needs to be a getter to avoid creating a breaking change.
-      get firstHiddenTime() {
-        return getFirstHiddenTime();
-      }
-
-    };
-
-}());
+    }
+  };
+  var eachEventType = function eachEventType(callback) {
+    var eventTypes = ['mousedown', 'keydown', 'touchstart', 'pointerdown'];
+    eventTypes.forEach((function(type) {
+      return callback(type, onInput, listenerOpts);
+    }));
+  };
+  var firstHiddenTime = document.visibilityState === 'hidden' ? 0 : Infinity;
+  var onVisibilityChange = function onVisibilityChange(event) {
+    if (document.visibilityState === 'hidden') {
+      firstHiddenTime = event.timeStamp;
+      removeEventListener('visibilitychange', onVisibilityChange, true);
+    }
+  };
+  addEventListener('visibilitychange', onVisibilityChange, true);
+  var getFirstHiddenTime = function getFirstHiddenTime() {
+    return firstHiddenTime;
+  };
+  resetFirstInputPolyfill();
+  self.webVitals = {
+    firstInputPolyfill: firstInputPolyfill,
+    resetFirstInputPolyfill: resetFirstInputPolyfill,
+    get firstHiddenTime() {
+      return getFirstHiddenTime();
+    },
+  };
+})();

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -95,6 +95,7 @@
     return firstHiddenTime;
   };
   resetFirstInputPolyfill();
+
   self.webVitals = {
     firstInputPolyfill: firstInputPolyfill,
     resetFirstInputPolyfill: resetFirstInputPolyfill,

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -1,11 +1,10 @@
 /**
  * web-vitals v2.1.0 polyfill
  */
-(function() {
-  'use strict';
 
+(function() {
   // This ensures that we do not initialize Core Web Vitals for non-browser environments
-  if(typeof document === 'undefined') {
+  if (typeof document === 'undefined') {
     return;
   }
 
@@ -103,3 +102,4 @@
     },
   };
 })();
+

--- a/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js
@@ -1,5 +1,6 @@
 /**
  * web-vitals v2.1.0 polyfill
+ * This comes from the google web-vital repository, polyfill script @https://github.com/GoogleChrome/web-vitals
  */
 
 (function() {

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -6,8 +6,8 @@
 (function(exports) {
   'use strict';
 
-  // This ensures that we do not initialize Core Web Vitals for non-browser environments
-  if(typeof document === 'undefined') {
+  // Raygun: This ensures that we do not initialize Core Web Vitals for non-browser environments
+  if (typeof document === 'undefined') {
     return;
   }
 

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -3,7 +3,7 @@
  * This comes from the google web-vital repository, base only script @https://github.com/GoogleChrome/web-vitals
  */
 
-(function(exports) {
+var webVitals = (function() {
   'use strict';
 
   // Raygun: This ensures that we do not initialize Core Web Vitals for non-browser environments
@@ -299,6 +299,6 @@
   exports.getLCP = getLCP;
   exports.getTTFB = getTTFB;
   Object.defineProperty(exports, '__esModule', { value: true });
-})(this.webVitals = this.webVitals || {});
+})();
 
 

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -283,7 +283,8 @@
     var metric = initMetric('TTFB');
     afterLoad((function() {
       try {
-        var navigationEntry = performance.getEntriesByType('navigation')[0] || getNavigationEntryFromPerformanceTiming();
+        var navTiming = performance.getEntriesByType('navigation');
+        var navigationEntry = !!navTiming ? navTiming[0] : getNavigationEntryFromPerformanceTiming();
         metric.value = metric.delta = navigationEntry.responseStart;
         if (metric.value < 0) return;
         metric.entries = [navigationEntry];

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -4,7 +4,6 @@
  */
 
 (function() {
-  'use strict';
 
   // Raygun: This ensures that we do not initialize Core Web Vitals for non-browser environments
   if (typeof document === 'undefined') {
@@ -293,6 +292,7 @@
       }
     }));
   };
+  
   window.webVitals.getCLS = getCLS;
   window.webVitals.getFCP = getFCP;
   window.webVitals.getFID = getFID;

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -1,567 +1,136 @@
 /**
+ * web-vitals v2.1.0
  * This comes from the google web-vital repository, base only script @ https://github.com/GoogleChrome/web-vitals
  */
-(function () {
-    // This ensures that we do not initilize Core Web Vitals for non-browser environments
-    if(typeof document === 'undefined') {
-      return;
+
+!function (e) {
+  "use strict";
+
+  // This ensures that we do not initialize Core Web Vitals for non-browser environments
+  if(typeof document === 'undefined') {
+    return;
+  }
+
+  var t = function (e, t) {
+    return {
+      name: e,
+      value: void 0 === t ? -1 : t,
+      delta: 0,
+      entries: [],
+      id: "v2-".concat(Date.now(), "-").concat(Math.floor(8999999999999 * Math.random()) + 1e12)
     }
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-
-    /**
-     * Performantly generate a unique, 30-char string by combining a version
-     * number, the current timestamp with a 13-digit number integer.
-     * @return {string}
-     */
-    var generateUniqueID = function generateUniqueID() {
-      return "v1-".concat(Date.now(), "-").concat(Math.floor(Math.random() * (9e12 - 1)) + 1e12);
+  }, n = function (e, t) {
+    try {
+      if (PerformanceObserver.supportedEntryTypes.includes(e)) {
+        if ("first-input" === e && !("PerformanceEventTiming" in self)) return;
+        var n = new PerformanceObserver((function (e) {
+          return e.getEntries().map(t)
+        }));
+        return n.observe({type: e, buffered: !0}), n
+      }
+    } catch (e) {
+    }
+  }, i = function (e, t) {
+    var n = function n(i) {
+      "pagehide" !== i.type && "hidden" !== document.visibilityState || (e(i), t && (removeEventListener("visibilitychange", n, !0), removeEventListener("pagehide", n, !0)))
     };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var initMetric = function initMetric(name, value) {
-      return {
-        name: name,
-        value: typeof value === 'undefined' ? -1 : value,
-        delta: 0,
-        entries: [],
-        id: generateUniqueID()
+    addEventListener("visibilitychange", n, !0), addEventListener("pagehide", n, !0)
+  }, a = function (e) {
+    addEventListener("pageshow", (function (t) {
+      t.persisted && e(t)
+    }), !0)
+  }, r = function (e, t, n) {
+    var i;
+    return function (a) {
+      t.value >= 0 && (a || n) && (t.delta = t.value - (i || 0), (t.delta || void 0 === i) && (i = t.value, e(t)))
+    }
+  }, o = -1, u = function () {
+    i((function (e) {
+      var t = e.timeStamp;
+      o = t
+    }), !0)
+  }, s = function () {
+    return o < 0 && ((o = self.webVitals.firstHiddenTime) === 1 / 0 && u(), a((function () {
+      setTimeout((function () {
+        o = "hidden" === document.visibilityState ? 0 : 1 / 0, u()
+      }), 0)
+    }))), {
+      get firstHiddenTime() {
+        return o
+      }
+    }
+  }, c = function (e, i) {
+    var o, u = s(), c = t("FCP"), f = function (e) {
+        "first-contentful-paint" === e.name && (m && m.disconnect(), e.startTime < u.firstHiddenTime && (c.value = e.startTime, c.entries.push(e), o(!0)))
+      }, d = performance.getEntriesByName && performance.getEntriesByName("first-contentful-paint")[0],
+      m = d ? null : n("paint", f);
+    (d || m) && (o = r(e, c, i), d && f(d), a((function (n) {
+      c = t("FCP"), o = r(e, c, i), requestAnimationFrame((function () {
+        requestAnimationFrame((function () {
+          c.value = performance.now() - n.timeStamp, o(!0)
+        }))
+      }))
+    })))
+  }, f = !1, d = -1, m = new Set;
+  e.getCLS = function (e, o) {
+    f || (c((function (e) {
+      d = e.value
+    })), f = !0);
+    var u, s = function (t) {
+      d > -1 && e(t)
+    }, m = t("CLS", 0), v = 0, l = [], p = function (e) {
+      if (!e.hadRecentInput) {
+        var t = l[0], n = l[l.length - 1];
+        v && e.startTime - n.startTime < 1e3 && e.startTime - t.startTime < 5e3 ? (v += e.value, l.push(e)) : (v = e.value, l = [e]), v > m.value && (m.value = v, m.entries = l, u())
+      }
+    }, g = n("layout-shift", p);
+    g && (u = r(s, m, o), i((function () {
+      g.takeRecords().map(p), u(!0)
+    })), a((function () {
+      v = 0, d = -1, m = t("CLS", 0), u = r(s, m, o)
+    })))
+  }, e.getFCP = c, e.getFID = function (e, o) {
+    var u, c = s(), f = t("FID"), d = function (e) {
+      e.startTime < c.firstHiddenTime && (f.value = e.processingStart - e.startTime, f.entries.push(e), u(!0))
+    }, m = n("first-input", d);
+    u = r(e, f, o), m && i((function () {
+      m.takeRecords().map(d), m.disconnect()
+    }), !0), m || window.webVitals.firstInputPolyfill(d), a((function () {
+      f = t("FID"), u = r(e, f, o), window.webVitals.resetFirstInputPolyfill(), window.webVitals.firstInputPolyfill(d)
+    }))
+  }, e.getLCP = function (e, o) {
+    var u, c = s(), f = t("LCP"), d = function (e) {
+      var t = e.startTime;
+      t < c.firstHiddenTime && (f.value = t, f.entries.push(e)), u()
+    }, v = n("largest-contentful-paint", d);
+    if (v) {
+      u = r(e, f, o);
+      var l = function () {
+        m.has(f.id) || (v.takeRecords().map(d), v.disconnect(), m.add(f.id), u(!0))
       };
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-
-    /**
-     * Takes a performance entry type and a callback function, and creates a
-     * `PerformanceObserver` instance that will observe the specified entry type
-     * with buffering enabled and call the callback _for each entry_.
-     *
-     * This function also feature-detects entry support and wraps the logic in a
-     * try/catch to avoid errors in unsupporting browsers.
-     */
-    var observe = function observe(type, callback) {
+      ["keydown", "click"].forEach((function (e) {
+        addEventListener(e, l, {once: !0, capture: !0})
+      })), i(l, !0), a((function (n) {
+        f = t("LCP"), u = r(e, f, o), requestAnimationFrame((function () {
+          requestAnimationFrame((function () {
+            f.value = performance.now() - n.timeStamp, m.add(f.id), u(!0)
+          }))
+        }))
+      }))
+    }
+  }, e.getTTFB = function (e) {
+    var n, i = t("TTFB");
+    n = function () {
       try {
-        if (PerformanceObserver.supportedEntryTypes.includes(type)) {
-          var po = new PerformanceObserver(function (l) {
-            return l.getEntries().map(callback);
-          });
-          po.observe({
-            type: type,
-            buffered: true
-          });
-          return po;
-        }
-      } catch (e) {// Do nothing.
+        var t = performance.getEntriesByType("navigation")[0] || function () {
+          var e = performance.timing, t = {entryType: "navigation", startTime: 0};
+          for (var n in e) "navigationStart" !== n && "toJSON" !== n && (t[n] = Math.max(e[n] - e.navigationStart, 0));
+          return t
+        }();
+        if (i.value = i.delta = t.responseStart, i.value < 0) return;
+        i.entries = [t], e(i)
+      } catch (e) {
       }
-
-      return;
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var beforeUnloadFixAdded = false;
-    var onHidden = function onHidden(cb, once) {
-      // Adding a `beforeunload` listener is needed to fix this bug:
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=987409
-      if (!beforeUnloadFixAdded && // Avoid adding this in Firefox as it'll break bfcache:
-      // https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
-      // @ts-ignore
-      typeof InstallTrigger === 'undefined') {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        addEventListener('beforeunload', function () {});
-        beforeUnloadFixAdded = true;
-      }
-
-      var onVisibilityChange = function onVisibilityChange(event) {
-        if (document.visibilityState === 'hidden') {
-          cb(event);
-
-          if (once) {
-            removeEventListener('visibilitychange', onVisibilityChange, true);
-          }
-        }
-      };
-
-      addEventListener('visibilitychange', onVisibilityChange, true);
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var onBFCacheRestore = function onBFCacheRestore(cb) {
-      addEventListener('pageshow', function (event) {
-        if (event.persisted) {
-          cb(event);
-        }
-      }, true);
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var finalMetrics = typeof WeakSet === 'function' ? new WeakSet() : new Set();
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var bindReporter = function bindReporter(callback, metric, reportAllChanges) {
-      var prevValue;
-      return function () {
-        if (metric.value >= 0) {
-          if (reportAllChanges || finalMetrics.has(metric) || document.visibilityState === 'hidden') {
-            metric.delta = metric.value - (prevValue || 0); // Report the metric if there's a non-zero delta, if the metric is
-            // final, or if no previous value exists (which can happen in the case
-            // of the document becoming hidden when the metric value is 0).
-            // See: https://github.com/GoogleChrome/web-vitals/issues/14
-
-            if (metric.delta || prevValue === undefined) {
-              prevValue = metric.value;
-              callback(metric);
-            }
-          }
-        }
-      };
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var getCLS = function getCLS(onReport, reportAllChanges) {
-      var metric = initMetric('CLS', 0);
-      var report;
-
-      var entryHandler = function entryHandler(entry) {
-        // Only count layout shifts without recent user input.
-        if (!entry.hadRecentInput) {
-          metric.value += entry.value;
-          metric.entries.push(entry);
-          report();
-        }
-      };
-
-      var po = observe('layout-shift', entryHandler);
-
-      if (po) {
-        report = bindReporter(onReport, metric, reportAllChanges);
-        onHidden(function () {
-          po.takeRecords().map(entryHandler);
-          report();
-        });
-        onBFCacheRestore(function () {
-          metric = initMetric('CLS', 0);
-          report = bindReporter(onReport, metric, reportAllChanges);
-        });
-      }
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var firstHiddenTime = -1;
-
-    var initHiddenTime = function initHiddenTime() {
-      return document.visibilityState === 'hidden' ? 0 : Infinity;
-    };
-
-    var trackChanges = function trackChanges() {
-      // Update the time if/when the document becomes hidden.
-      onHidden(function (_ref) {
-        var timeStamp = _ref.timeStamp;
-        firstHiddenTime = timeStamp;
-      }, true);
-    };
-
-    var getFirstHidden = function getFirstHidden() {
-      if (firstHiddenTime < 0) {
-        // If the document is hidden when this code runs, assume it was hidden
-        // since navigation start. This isn't a perfect heuristic, but it's the
-        // best we can do until an API is available to support querying past
-        // visibilityState.
-        {
-          firstHiddenTime = !!self.webVitals ? self.webVitals.firstHiddenTime : initHiddenTime();
-
-          if (firstHiddenTime === Infinity) {
-            trackChanges();
-          }
-        } // Reset the time on bfcache restores.
-
-
-        onBFCacheRestore(function () {
-          // Schedule a task in order to track the `visibilityState` once it's
-          // had an opportunity to change to visible in all browsers.
-          // https://bugs.chromium.org/p/chromium/issues/detail?id=1133363
-          setTimeout(function () {
-            firstHiddenTime = initHiddenTime();
-            trackChanges();
-          }, 0);
-        });
-      }
-
-      return {
-        get timeStamp() {
-          return firstHiddenTime;
-        }
-
-      };
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var getFCP = function getFCP(onReport, reportAllChanges) {
-      var firstHidden = getFirstHidden();
-      var metric = initMetric('FCP');
-      var report;
-
-      var entryHandler = function entryHandler(entry) {
-        if (entry.name === 'first-contentful-paint') {
-          if (po) {
-            po.disconnect();
-          } // Only report if the page wasn't hidden prior to the first paint.
-
-
-          if (entry.startTime < firstHidden.timeStamp) {
-            metric.value = entry.startTime;
-            metric.entries.push(entry);
-            finalMetrics.add(metric);
-            report();
-          }
-        }
-      };
-
-      var po = observe('paint', entryHandler);
-
-      if (po) {
-        report = bindReporter(onReport, metric, reportAllChanges);
-        onBFCacheRestore(function (event) {
-          metric = initMetric('FCP');
-          report = bindReporter(onReport, metric, reportAllChanges);
-          requestAnimationFrame(function () {
-            requestAnimationFrame(function () {
-              metric.value = performance.now() - event.timeStamp;
-              finalMetrics.add(metric);
-              report();
-            });
-          });
-        });
-      }
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var getFID = function getFID(onReport, reportAllChanges) {
-      var firstHidden = getFirstHidden();
-      var metric = initMetric('FID');
-      var report;
-
-      var entryHandler = function entryHandler(entry) {
-        // Only report if the page wasn't hidden prior to the first input.
-        if (entry.startTime < firstHidden.timeStamp) {
-          metric.value = entry.processingStart - entry.startTime;
-          metric.entries.push(entry);
-          finalMetrics.add(metric);
-          report();
-        }
-      };
-
-      var po = observe('first-input', entryHandler);
-      report = bindReporter(onReport, metric, reportAllChanges);
-
-      if (po) {
-        onHidden(function () {
-          po.takeRecords().map(entryHandler);
-          po.disconnect();
-        }, true);
-      }
-
-      {
-        // Prefer the native implementation if available,
-        if (!po) {
-          window.webVitals.firstInputPolyfill(entryHandler);
-        }
-
-        onBFCacheRestore(function () {
-          metric = initMetric('FID');
-          report = bindReporter(onReport, metric, reportAllChanges);
-          window.webVitals.resetFirstInputPolyfill();
-          window.webVitals.firstInputPolyfill(entryHandler);
-        });
-      }
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-    var getLCP = function getLCP(onReport, reportAllChanges) {
-      var firstHidden = getFirstHidden();
-      var metric = initMetric('LCP');
-      var report;
-
-      var entryHandler = function entryHandler(entry) {
-        // The startTime attribute returns the value of the renderTime if it is not 0,
-        // and the value of the loadTime otherwise.
-        var value = entry.startTime; // If the page was hidden prior to paint time of the entry,
-        // ignore it and mark the metric as final, otherwise add the entry.
-
-        if (value < firstHidden.timeStamp) {
-          metric.value = value;
-          metric.entries.push(entry);
-        }
-
-        report();
-      };
-
-      var po = observe('largest-contentful-paint', entryHandler);
-
-      if (po) {
-        report = bindReporter(onReport, metric, reportAllChanges);
-
-        var stopListening = function stopListening() {
-          if (!finalMetrics.has(metric)) {
-            po.takeRecords().map(entryHandler);
-            po.disconnect();
-            finalMetrics.add(metric);
-            report();
-          }
-        }; // Stop listening after input. Note: while scrolling is an input that
-        // stop LCP observation, it's unreliable since it can be programmatically
-        // generated. See: https://github.com/GoogleChrome/web-vitals/issues/75
-
-
-        ['keydown', 'click'].forEach(function (type) {
-          addEventListener(type, stopListening, {
-            once: true,
-            capture: true
-          });
-        });
-        onHidden(stopListening, true);
-        onBFCacheRestore(function (event) {
-          metric = initMetric('LCP');
-          report = bindReporter(onReport, metric, reportAllChanges);
-          requestAnimationFrame(function () {
-            requestAnimationFrame(function () {
-              metric.value = performance.now() - event.timeStamp;
-              finalMetrics.add(metric);
-              report();
-            });
-          });
-        });
-      }
-    };
-
-    /*
-     * Copyright 2020 Google LLC
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     https://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-
-    var afterLoad = function afterLoad(callback) {
-      if (document.readyState === 'complete') {
-        // Queue a task so the callback runs after `loadEventEnd`.
-        setTimeout(callback, 0);
-      } else {
-        // Use `pageshow` so the callback runs after `loadEventEnd`.
-        addEventListener('pageshow', callback);
-      }
-    };
-
-    var getNavigationEntryFromPerformanceTiming = function getNavigationEntryFromPerformanceTiming() {
-      // Really annoying that TypeScript errors when using `PerformanceTiming`.
-      var timing = performance.timing;
-      var navigationEntry = {
-        entryType: 'navigation',
-        startTime: 0
-      };
-
-      for (var key in timing) {
-        if (key !== 'navigationStart' && key !== 'toJSON') {
-          navigationEntry[key] = Math.max(timing[key] - timing.navigationStart, 0);
-        }
-      }
-
-      return navigationEntry;
-    };
-
-    var getTTFB = function getTTFB(onReport) {
-      var metric = initMetric('TTFB');
-      afterLoad(function () {
-        try {
-          // Use the NavigationTiming L2 entry if available.
-          var navTimings = performance.getEntriesByType('navigation');
-          var navigationEntry = !!navTimings ? navTimings[0] : getNavigationEntryFromPerformanceTiming();
-          metric.value = metric.delta = navigationEntry.responseStart;
-          metric.entries = [navigationEntry];
-          onReport(metric);
-        } catch (error) {// Do nothing.
-        }
-      });
-    };
-
-    window.webVitals.getCLS = getCLS;
-    window.webVitals.getFCP = getFCP;
-    window.webVitals.getFID = getFID;
-    window.webVitals.getLCP = getLCP;
-    window.webVitals.getTTFB = getTTFB;
-}());
+    }, "complete" === document.readyState ? setTimeout(n, 0) : addEventListener("pageshow", n)
+  }, Object.defineProperty(e, "__esModule", {value: !0})
+}(this.webVitals = this.webVitals || {});

--- a/src/raygun.rum/vendor/web-vitals.vendor.js
+++ b/src/raygun.rum/vendor/web-vitals.vendor.js
@@ -3,7 +3,7 @@
  * This comes from the google web-vital repository, base only script @https://github.com/GoogleChrome/web-vitals
  */
 
-var webVitals = (function() {
+(function() {
   'use strict';
 
   // Raygun: This ensures that we do not initialize Core Web Vitals for non-browser environments
@@ -293,12 +293,11 @@ var webVitals = (function() {
       }
     }));
   };
-  exports.getCLS = getCLS;
-  exports.getFCP = getFCP;
-  exports.getFID = getFID;
-  exports.getLCP = getLCP;
-  exports.getTTFB = getTTFB;
-  Object.defineProperty(exports, '__esModule', { value: true });
+  window.webVitals.getCLS = getCLS;
+  window.webVitals.getFCP = getFCP;
+  window.webVitals.getFID = getFID;
+  window.webVitals.getLCP = getLCP;
+  window.webVitals.getTTFB = getTTFB;
 })();
 
 


### PR DESCRIPTION
## Overview

Upgrade the [web-vitals](https://github.com/GoogleChrome/web-vitals) vendor scripts to the latest version ([v2.1.0](https://github.com/GoogleChrome/web-vitals/releases/tag/v2.1.0)). 

This version includes several updates to the library, including the following notable improvements:

- [Firefox compatibility improvements](https://github.com/GoogleChrome/web-vitals/pull/143/files)
- [CLS tracking improvement](https://github.com/GoogleChrome/web-vitals/pull/149/files) 
- [Only track CLS if FCP is being tracked](https://github.com/GoogleChrome/web-vitals/pull/154/files)

### Scripts updated

- [web-vitals-polyfills.vendor.js](https://github.com/MindscapeHQ/raygun4js/blob/3a4b0bd93359552a83b94112120534d92578af9b/src/raygun.rum/vendor/web-vitals-polyfills.vendor.js)
- [web-vitals.vendor.js](https://github.com/MindscapeHQ/raygun4js/blob/3a4b0bd93359552a83b94112120534d92578af9b/src/raygun.rum/vendor/web-vitals.vendor.js)