### PR TITLE
Discard errors from browser extensions if ignore3rdPartyErrors option is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.23.0
+- If `ignore3rdPartyErrors` option is true, discard errors that match the pattern of errors from browser extensions, bots and crawlers
+
 * v2.22.5
 - Fixes an issue with Core Web Vital tracking not being able to be disabled.
 - Fixes an issue where `navigator.sendBeacon` errors were not being handled gracefully.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,9 +22,52 @@ module.exports = function(grunt) {
       },
       dist: {
         files: {
-          'dist/raygun.js': ['tracekit/tracekit.js', 'src/raygun.tracekit.jquery.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js'],
-          'dist/raygun.vanilla.js': ['tracekit/tracekit.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js'],
-          'dist/raygun.umd.js': ['src/umd.intro.js', 'tracekit/tracekit.js', 'src/polyfills.js', 'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js', 'src/raygun.tracekit.jquery.js', 'src/raygun.utilities/index.js', 'src/raygun.network-tracking.js', 'src/raygun.breadcrumbs.js', 'src/raygun.rum/core-web-vitals.js', 'src/raygun.js', 'src/raygun.rum/vendor/web-vitals.vendor.js', 'src/raygun.rum/index.js', 'src/raygun.loader.js', 'src/umd.outro.js']
+          'dist/raygun.js': [
+            'tracekit/tracekit.js',
+            'src/raygun.tracekit.jquery.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.utilities/errorUtilities.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js'
+          ],
+          'dist/raygun.vanilla.js': [
+            'tracekit/tracekit.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.utilities/errorUtilities.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js'
+          ],
+          'dist/raygun.umd.js': [
+            'src/umd.intro.js',
+            'tracekit/tracekit.js',
+            'src/polyfills.js',
+            'src/raygun.rum/vendor/web-vitals-polyfills.vendor.js',
+            'src/raygun.tracekit.jquery.js',
+            'src/raygun.utilities/index.js',
+            'src/raygun.utilities/errorUtilities.js',
+            'src/raygun.network-tracking.js',
+            'src/raygun.breadcrumbs.js',
+            'src/raygun.rum/core-web-vitals.js',
+            'src/raygun.js',
+            'src/raygun.rum/vendor/web-vitals.vendor.js',
+            'src/raygun.rum/index.js',
+            'src/raygun.loader.js',
+            'src/umd.outro.js'
+          ]
         }
       }
     },

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ The second parameter should contain one or more of these keys and a value to cus
 
 `ignore3rdPartyErrors` - ignores any errors that have no stack trace information. This will discard any errors that occur completely
 within 3rd party scripts - if code loaded from the current domain called the 3rd party function, it will have at least one stack line
-and will still be sent. _Note: IE 9 and below have no stacktrace information and errors will be discarded with this enabled._
+and will still be sent. Errors that occur in browser extensions or that have been triggered by bots/crawlers that appear to come from 
+your website will also be ignored. _Note: IE 9 and below have no stacktrace information and errors will be discarded with this enabled._
 
 `excludedHostnames` - Prevents errors from being sent from certain hostnames (domains) by providing an array of strings or RegExp
 objects (for partial matches). Each should match the hostname or TLD that you want to exclude. Note that protocols are not tested.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.22.5",
+  "version": "2.23.0",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.22.5",
+  "version": "2.23.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@wdio/spec-reporter": "^6.1.5",
     "@wdio/static-server-service": "^6.0.16",
     "@wdio/sync": "^6.1.8",
-    "chromedriver": "^90.0.0",
+    "chromedriver": "^92.0.1",
     "cross-env": "^7.0.2",
     "grunt": "^1.1.0",
     "grunt-contrib-clean": "^2.0.0",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.22.5</version>
+    <version>2.23.0</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -124,7 +124,7 @@ var raygunFactory = function(window, $, undefined) {
         _captureMissingRequests = options.captureMissingRequests || false;
         _automaticPerformanceCustomTimings = options.automaticPerformanceCustomTimings || false;
         _trackCoreWebVitals = options.trackCoreWebVitals === undefined ? true : options.trackCoreWebVitals;
-  
+
         if (options.apiUrl) {
           _raygunApiUrl = options.apiUrl;
         }
@@ -1145,7 +1145,7 @@ var raygunFactory = function(window, $, undefined) {
       return true;
     }
 
-    if (Raygun.ErrorUtilities.isInvalidStackTrace(stackTrace)) {
+    if (!Raygun.ErrorUtilities.isValidStackTrace(stackTrace)) {
       Raygun.Utilities.log(
         'Raygun4JS: cancelling send due to invalid stacktrace data',
         stackTrace

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -4,7 +4,12 @@
 
 window.raygunErrorUtilitiesFactory = function (window, Raygun) {
   var scriptError = 'Script error';
-  var currentLocation = window.location;
+  var currentLocation = !!window && !!window.location ? window.location : {
+    host: null,
+    toString: function toString() {
+      return null;
+    }
+  };
   var currentUrl = currentLocation.toString();
   var utils = Raygun.Utilities;
 

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -6,6 +6,7 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
   var scriptError = 'Script error';
   var currentLocation = window.location;
   var currentUrl = currentLocation.toString();
+  var utils = Raygun.Utilities;
 
   var isBrowserExtensionUrl = function isBrowserExtensionUrl(url) {
     return url.indexOf('chrome-extension://') === 0 ||
@@ -15,18 +16,18 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
   };
 
   // The stack line is deemed invalid if all of the following conditions are met:
-  // 1. The line and column numbers are zero
+  // 1. The line and column numbers are null *or* zero
   // 2. The url is nil *or* the same as the current location *and* the function is '?'
   var isInvalidStackLine = function isInvalidStackLine(stackLine) {
-    if (!Raygun.Utilities.isNil(stackLine.line) && stackLine.line > 0) {
+    if (!utils.isNil(stackLine.line) && stackLine.line > 0) {
       return false;
     }
 
-    if (!Raygun.Utilities.isNil(stackLine.column) && stackLine.column > 0) {
+    if (!utils.isNil(stackLine.column) && stackLine.column > 0) {
       return false;
     }
 
-    if (!Raygun.Utilities.isNil(stackLine.url)) {
+    if (!utils.isNil(stackLine.url)) {
       return currentUrl.indexOf(stackLine.url) !== -1 && stackLine.func === '?';
     }
 
@@ -54,10 +55,10 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
         msg = scriptError;
       }
 
-      return !Raygun.Utilities.isReactNative() &&
+      return !utils.isReactNative() &&
         typeof msg.substring === 'function' &&
         msg.substring(0, scriptError.length) === scriptError &&
-        !Raygun.Utilities.isNil(stackTrace.stack[0].url) &&
+        !utils.isNil(stackTrace.stack[0].url) &&
         stackTrace.stack[0].url.indexOf(currentLocation.host) === -1 &&
         (stackTrace.stack[0].line === 0 || stackTrace.stack[0].func === '?');
     },
@@ -72,20 +73,21 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
     isBrowserExtensionError: function isBrowserExtensionError(stackTrace) {
       var stack = stackTrace.stack;
 
-      if (Raygun.Utilities.isEmpty(stack)) {
+      if (utils.isEmpty(stack)) {
         return false;
       }
 
-      return Raygun.Utilities.any(stack, function (stackLine) {
+      return utils.any(stack, function (stackLine) {
         var url = stackLine.url;
 
-        return !Raygun.Utilities.isNil(url) && isBrowserExtensionUrl(url);
+        return !utils.isNil(url) && isBrowserExtensionUrl(url);
       });
     },
 
     /**
      * Check if all lines in the stack are invalid, i.e. they have a line and column number of zero and a url of null or
-     * a url that matches the current host *and* a function called '?'.
+     * a url that matches the current host *and* a function called '?'. This is a common pattern of errors triggered in
+     * browser extensions or by bots/crawlers.
      *
      * @param stackTrace
      * @returns {boolean}
@@ -93,11 +95,11 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
     isInvalidStackTrace: function isInvalidStackTrace(stackTrace) {
       var stack = stackTrace.stack;
 
-      if (Raygun.Utilities.isNil(stackTrace.message) || Raygun.Utilities.isEmpty(stack)) {
+      if (utils.isNil(stackTrace.message) || utils.isEmpty(stack)) {
         return true;
       }
 
-      return Raygun.Utilities.all(stack, isInvalidStackLine);
+      return utils.all(stack, isInvalidStackLine);
     },
 
     /**
@@ -113,8 +115,8 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
 
       for (var i = 0; !foundValidDomain && stackTrace.stack && i < stackTrace.stack.length; i++) {
         if (
-          !Raygun.Utilities.isNil(stackTrace.stack[i]) &&
-          !Raygun.Utilities.isNil(stackTrace.stack[i].url)
+          !utils.isNil(stackTrace.stack[i]) &&
+          !utils.isNil(stackTrace.stack[i].url)
         ) {
           for (var j in whitelistedScriptDomains) {
             if (whitelistedScriptDomains.hasOwnProperty(j)) {

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -16,7 +16,7 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
   };
 
   // The stack line is deemed invalid if all of the following conditions are met:
-  // 1. The line and column numbers are null *or* zero
+  // 1. The line and column numbers are nil *or* zero
   // 2. The url is nil *or* the same as the current location *and* the function is '?'
   var isInvalidStackLine = function isInvalidStackLine(stackLine) {
     if (!utils.isNil(stackLine.line) && stackLine.line > 0) {
@@ -51,7 +51,7 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
         msg = options.status;
       }
 
-      if (typeof msg === 'undefined') {
+      if (utils.isNil(msg)) {
         msg = scriptError;
       }
 
@@ -114,19 +114,18 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
       var foundValidDomain = false;
 
       for (var i = 0; !foundValidDomain && stackTrace.stack && i < stackTrace.stack.length; i++) {
-        if (
-          !utils.isNil(stackTrace.stack[i]) &&
-          !utils.isNil(stackTrace.stack[i].url)
-        ) {
+        var stackLine = stackTrace.stack[i];
+
+        if (!utils.isNil(stackLine) && !utils.isNil(stackLine.url)) {
           for (var j in whitelistedScriptDomains) {
             if (whitelistedScriptDomains.hasOwnProperty(j)) {
-              if (stackTrace.stack[i].url.indexOf(whitelistedScriptDomains[j]) > -1) {
+              if (stackLine.url.indexOf(whitelistedScriptDomains[j]) > -1) {
                 foundValidDomain = true;
               }
             }
           }
 
-          if (stackTrace.stack[i].url.indexOf(currentLocation.host) > -1) {
+          if (stackLine.url.indexOf(currentLocation.host) > -1) {
             foundValidDomain = true;
           }
         }

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -18,17 +18,17 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
   // The stack line is deemed invalid if all of the following conditions are met:
   // 1. The line and column numbers are nil *or* zero
   // 2. The url is nil *or* the same as the current location *and* the function is '?'
-  var isInvalidStackLine = function isInvalidStackLine(stackLine) {
+  var isValidStackLine = function isValidStackLine(stackLine) {
     if (!utils.isNil(stackLine.line) && stackLine.line > 0) {
-      return false;
+      return true;
     }
 
     if (!utils.isNil(stackLine.column) && stackLine.column > 0) {
-      return false;
+      return true;
     }
 
-    if (!utils.isNil(stackLine.url)) {
-      return currentUrl.indexOf(stackLine.url) !== -1 && stackLine.func === '?';
+    if (utils.isNil(stackLine.url) || currentUrl.indexOf(stackLine.url) !== -1 && stackLine.func === '?') {
+      return false;
     }
 
     return true;
@@ -92,14 +92,14 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
      * @param stackTrace
      * @returns {boolean}
      */
-    isInvalidStackTrace: function isInvalidStackTrace(stackTrace) {
+    isValidStackTrace: function isValidStackTrace(stackTrace) {
       var stack = stackTrace.stack;
 
       if (utils.isNil(stackTrace.message) || utils.isEmpty(stack)) {
-        return true;
+        return false;
       }
 
-      return utils.all(stack, isInvalidStackLine);
+      return utils.any(stack, isValidStackLine);
     },
 
     /**

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -1,0 +1,136 @@
+/**
+ * @prettier
+ */
+
+window.raygunErrorUtilitiesFactory = function (window, Raygun) {
+  var scriptError = 'Script error';
+  var currentLocation = window.location;
+  var currentUrl = currentLocation.toString();
+
+  var isBrowserExtensionUrl = function isBrowserExtensionUrl(url) {
+    return url.indexOf('chrome-extension://') === 0 ||
+      url.indexOf('moz-extension://') === 0 ||
+      url.indexOf('safari-extension://') === 0 ||
+      url.indexOf('safari-web-extension://') === 0;
+  };
+
+  // The stack line is deemed invalid if all of the following conditions are met:
+  // 1. The line and column numbers are zero
+  // 2. The url is nil *or* the same as the current location *and* the function is '?'
+  var isInvalidStackLine = function isInvalidStackLine(stackLine) {
+    if (!Raygun.Utilities.isNil(stackLine.line) && stackLine.line > 0) {
+      return false;
+    }
+
+    if (!Raygun.Utilities.isNil(stackLine.column) && stackLine.column > 0) {
+      return false;
+    }
+
+    if (!Raygun.Utilities.isNil(stackLine.url)) {
+      return currentUrl.indexOf(stackLine.url) !== -1 && stackLine.func === '?';
+    }
+
+    return true;
+  };
+
+  return {
+    /**
+     * Check if the current stacktrace is a Script error from an external domain.
+     *
+     * @param stackTrace
+     * @param options
+     * @returns {boolean}
+     */
+    isScriptError: function isScriptError(stackTrace, options) {
+      var msg = scriptError;
+
+      if (stackTrace.message) {
+        msg = stackTrace.message;
+      } else if (options && options.status) {
+        msg = options.status;
+      }
+
+      if (typeof msg === 'undefined') {
+        msg = scriptError;
+      }
+
+      return !Raygun.Utilities.isReactNative() &&
+        typeof msg.substring === 'function' &&
+        msg.substring(0, scriptError.length) === scriptError &&
+        !Raygun.Utilities.isNil(stackTrace.stack[0].url) &&
+        stackTrace.stack[0].url.indexOf(currentLocation.host) === -1 &&
+        (stackTrace.stack[0].line === 0 || stackTrace.stack[0].func === '?');
+    },
+
+    /**
+     * Check if the stacktrace from a browser extension - if any stack line has a url that starts with a browser
+     * extension protocol (e.g. "chrome-extension://"), then this will return true.
+     *
+     * @param stackTrace
+     * @returns {boolean}
+     */
+    isBrowserExtensionError: function isBrowserExtensionError(stackTrace) {
+      var stack = stackTrace.stack;
+
+      if (Raygun.Utilities.isEmpty(stack)) {
+        return false;
+      }
+
+      return Raygun.Utilities.any(stack, function (stackLine) {
+        var url = stackLine.url;
+
+        return !Raygun.Utilities.isNil(url) && isBrowserExtensionUrl(url);
+      });
+    },
+
+    /**
+     * Check if all lines in the stack are invalid, i.e. they have a line and column number of zero and a url of null or
+     * a url that matches the current host *and* a function called '?'.
+     *
+     * @param stackTrace
+     * @returns {boolean}
+     */
+    isInvalidStackTrace: function isInvalidStackTrace(stackTrace) {
+      var stack = stackTrace.stack;
+
+      if (Raygun.Utilities.isNil(stackTrace.message) || Raygun.Utilities.isEmpty(stack)) {
+        return true;
+      }
+
+      return Raygun.Utilities.all(stack, isInvalidStackLine);
+    },
+
+    /**
+     * Check if the current stacktrace has any lines that have a url that matches the current url. This function can be
+     * passed a list of whitelisted domains that will be checked against.
+     *
+     * @param stackTrace
+     * @param whitelistedScriptDomains string[]
+     * @returns {boolean}
+     */
+    stackTraceHasValidDomain: function stackTraceHasValidDomain(stackTrace, whitelistedScriptDomains) {
+      var foundValidDomain = false;
+
+      for (var i = 0; !foundValidDomain && stackTrace.stack && i < stackTrace.stack.length; i++) {
+        if (
+          !Raygun.Utilities.isNil(stackTrace.stack[i]) &&
+          !Raygun.Utilities.isNil(stackTrace.stack[i].url)
+        ) {
+          for (var j in whitelistedScriptDomains) {
+            if (whitelistedScriptDomains.hasOwnProperty(j)) {
+              if (stackTrace.stack[i].url.indexOf(whitelistedScriptDomains[j]) > -1) {
+                foundValidDomain = true;
+              }
+            }
+          }
+
+          if (stackTrace.stack[i].url.indexOf(currentLocation.host) > -1) {
+            foundValidDomain = true;
+          }
+        }
+      }
+
+      return foundValidDomain;
+    }
+  };
+};

--- a/src/raygun.utilities/errorUtilities.js
+++ b/src/raygun.utilities/errorUtilities.js
@@ -90,9 +90,10 @@ window.raygunErrorUtilitiesFactory = function (window, Raygun) {
     },
 
     /**
-     * Check if all lines in the stack are invalid, i.e. they have a line and column number of zero and a url of null or
-     * a url that matches the current host *and* a function called '?'. This is a common pattern of errors triggered in
-     * browser extensions or by bots/crawlers.
+     * Check if any lines in the stack are valid, i.e. they do not match the criteria of having a null/zero line and
+     * column number and do not have a url equal to the current url with a function name of '?'.
+     *
+     * This is to filter out a common pattern of errors triggered in browser extensions or by bots/crawlers.
      *
      * @param stackTrace
      * @returns {boolean}

--- a/src/raygun.utilities/errorUtilities.spec.js
+++ b/src/raygun.utilities/errorUtilities.spec.js
@@ -18,7 +18,7 @@ const FakeRaygun = {
   Utilities: window.raygunUtilityFactory(FakeWindow, {})
 };
 
-var errorUtilities = window.raygunErrorUtilitiesFactory(FakeWindow, FakeRaygun);
+const errorUtilities = window.raygunErrorUtilitiesFactory(FakeWindow, FakeRaygun);
 
 describe('Error utilities', () => {
   describe('isScriptError', () => {
@@ -108,7 +108,8 @@ describe('Error utilities', () => {
 
     describe('stacktrace with all lines from browser extension', () => {
       it('will return true', () => {
-        var stackTrace = {
+        const stackTrace = {
+          message: 'Error in browser extension',
           stack: [
             {
               line: 2,
@@ -137,7 +138,7 @@ describe('Error utilities', () => {
 
     describe('stacktrace with a line not from a browser extension', () => {
       it('will return true', () => {
-        var stackTrace = {
+        const stackTrace = {
           stack: [
             {
               line: 3,
@@ -160,7 +161,7 @@ describe('Error utilities', () => {
 
     describe('stacktrace with no lines from a browser extension', () => {
       it('will return false', () => {
-        var stackTrace = {
+        const stackTrace = {
           stack: [
             {
               line: 4,

--- a/src/raygun.utilities/errorUtilities.spec.js
+++ b/src/raygun.utilities/errorUtilities.spec.js
@@ -1,0 +1,422 @@
+/**
+ * @prettier
+ */
+
+require('./');
+require('./errorUtilities');
+
+const fakeHost = 'example.com'
+const fakeLocation = `http://${fakeHost}/index.html?qs=1`;
+
+const FakeWindow = {
+  location: {
+    toString: () => fakeLocation,
+    host: fakeHost
+  }
+};
+const FakeRaygun = {
+  Utilities: window.raygunUtilityFactory(FakeWindow, {})
+};
+
+var errorUtilities = window.raygunErrorUtilitiesFactory(FakeWindow, FakeRaygun);
+
+describe('Error utilities', () => {
+  describe('isScriptError', () => {
+    describe('with no message', () => {
+      it('will return true', () => {
+        const stackTrace = {
+          stack: [
+            {
+              line: 0,
+              column: 0,
+              url: 'http://external.com/index.js',
+              func: '?'
+            }
+          ]
+        };
+        expect(errorUtilities.isScriptError(stackTrace, {})).toEqual(true);
+      });
+    });
+
+    describe('with "Script error" message, zero line number from an external domain', () => {
+      it('will return true', () => {
+        const stackTrace = {
+          message: 'Script error',
+          stack: [
+            {
+              line: 0,
+              column: 0,
+              url: 'http://external.com/index.js',
+              func: '?'
+            }
+          ]
+        };
+        expect(errorUtilities.isScriptError(stackTrace, {})).toEqual(true);
+      });
+    });
+  });
+
+  describe('isBrowserExtensionError', () => {
+    describe('with empty stack array', () => {
+      it('will return false', () => {
+        const stackTrace = {
+          stack: []
+        };
+
+        expect(errorUtilities.isBrowserExtensionError(stackTrace)).toEqual(false);
+      });
+    });
+
+    describe('with null url in stacktrace', () => {
+      it('will return false', () => {
+        const stackTrace = {
+          stack: [
+            {
+              line: 1,
+              column: 23,
+              func: '?'
+            }
+          ]
+        };
+
+        expect(errorUtilities.isBrowserExtensionError(stackTrace)).toEqual(false);
+      });
+    });
+
+    describe('stacktrace with all lines from browser extension', () => {
+      it('will return true', () => {
+        var stackTrace = {
+          stack: [
+            {
+              line: 2,
+              column: 345,
+              url: 'chrome-extension://test/index.js',
+              func: 'render'
+            },
+            {
+              line: 3,
+              column: 45,
+              url: 'chrome-extension://test/index.js',
+              func: 'show'
+            },
+            {
+              line: 4,
+              column: 567,
+              url: 'chrome-extension://test2/index.js',
+              func: 'run'
+            },
+          ]
+        };
+
+        expect(errorUtilities.isBrowserExtensionError(stackTrace)).toEqual(true);
+      });
+    });
+
+    describe('stacktrace with a line not from a browser extension', () => {
+      it('will return true', () => {
+        var stackTrace = {
+          stack: [
+            {
+              line: 3,
+              column: 45,
+              url: 'moz-extension://test/index.js',
+              func: 'run'
+            },
+            {
+              line: null,
+              column: null,
+              url: null,
+              func: 'b'
+            },
+          ]
+        };
+
+        expect(errorUtilities.isBrowserExtensionError(stackTrace)).toEqual(true);
+      });
+    });
+
+    describe('stacktrace with no lines from a browser extension', () => {
+      it('will return false', () => {
+        var stackTrace = {
+          stack: [
+            {
+              line: 4,
+              column: 567,
+              url: 'http://example.com/src/index.js',
+              func: 'show'
+            },
+            {
+              line: 3,
+              column: 45,
+              url: 'http://example.com/src/index.js',
+              func: 'run'
+            },
+          ]
+        };
+
+        expect(errorUtilities.isBrowserExtensionError(stackTrace)).toEqual(false);
+      });
+    });
+  });
+
+  describe('isInvalidStackTrace', () => {
+    describe('with null stack array', () => {
+      it('will return true', () => {
+        expect(errorUtilities.isInvalidStackTrace({
+          stack: null,
+        })).toEqual(true);
+      });
+    });
+
+    describe('with empty stack array', () => {
+      it('will return true', () => {
+        expect(errorUtilities.isInvalidStackTrace({
+          stack: [],
+        })).toEqual(true);
+      });
+    });
+
+    describe('with all null values in stack lines', () => {
+      it('will return true', () => {
+        expect(errorUtilities.isInvalidStackTrace({
+          stack: [
+            {
+              line: null,
+              column: null,
+              url: null,
+              func: '?'
+            }
+          ],
+        })).toEqual(true);
+      });
+    });
+
+    describe('with known error from bot', () => {
+      it('will return true', () => {
+        expect(errorUtilities.isInvalidStackTrace({
+          message: 'Object Not Found Matching Id:1',
+          stack: [
+            {
+              line: null,
+              column: null,
+              url: null,
+              func: 'Z'
+            }
+          ],
+        })).toEqual(true);
+      });
+    });
+
+    describe('with zero line and column numbers, function is "?"', () => {
+      describe('with a url that matches the current location', () => {
+        it('will return true', () => {
+          expect(errorUtilities.isInvalidStackTrace({
+            message: 'ResizeObserver loop limit exceeded',
+            stack: [
+              {
+                line: 0,
+                column: 0,
+                url: 'http://example.com/index.html',
+                func: '?'
+              }
+            ],
+          })).toEqual(true);
+        });
+      });
+
+      describe('with a url that does not match the current location', () => {
+        it('will return true', () => {
+          expect(errorUtilities.isInvalidStackTrace({
+            message: 'TypeError: undefined is not a function',
+            stack: [
+              {
+                line: 0,
+                column: 0,
+                url: 'http://other.com/index.html',
+                func: '?'
+              }
+            ],
+          })).toEqual(false);
+        });
+      });
+
+      describe('with valid stacktrace', () => {
+        describe('with all valid stack lines', () => {
+          it('will return false', () => {
+            expect(errorUtilities.isInvalidStackTrace({
+              message: 'Cannot read property \'fn\' of undefined',
+              stack: [
+                {
+                  line: 4,
+                  column: 162,
+                  url: 'http://example.com/index.js',
+                  func: 'fn'
+                },
+                {
+                  line: 65,
+                  column: 124,
+                  url: 'http://example.com/index.js',
+                  func: 'run'
+                },
+              ],
+            })).toEqual(false);
+          });
+        });
+
+        describe('with an invalid stack line', () => {
+          it('will return false', () => {
+            expect(errorUtilities.isInvalidStackTrace({
+              message: 'Cannot read property \'fn\' of undefined',
+              stack: [
+                {
+                  line: 32,
+                  column: 88,
+                  url: 'http://example.com/index.js',
+                  func: 'fn'
+                },
+                {
+                  line: null,
+                  column: null,
+                  url: null,
+                  func: 'Z'
+                },
+              ],
+            })).toEqual(false);
+          });
+        });
+      });
+    });
+  });
+
+  describe('stackTraceHasValidDomain', () => {
+    describe('with bad stacktrace values', () => {
+      describe('with null stack array', () => {
+        it('will return false', () => {
+          expect(errorUtilities.stackTraceHasValidDomain({
+            stack: null
+          }, [])).toEqual(false);
+        });
+      });
+      describe('with empty stack array', () => {
+        it('will return false', () => {
+          expect(errorUtilities.stackTraceHasValidDomain({
+            stack: []
+          }, [])).toEqual(false);
+        });
+      });
+    });
+
+    describe('with valid stacktrace', () => {
+      describe('with no whitelisted domains', () => {
+        describe('with no line that matches the current domain', () => {
+          it('will return false', () => {
+            expect(errorUtilities.stackTraceHasValidDomain({
+              stack: [
+                {
+                  line: 1,
+                  column: 23,
+                  url: 'http://external.com/index.js',
+                  func: 'run'
+                },
+                {
+                  line: 2,
+                  column: 34,
+                  url: 'http://another.com/index.js',
+                  func: 'show'
+                },
+              ]
+            }, [])).toEqual(false);
+          });
+        });
+
+        describe('with one line that matches the current domain', () => {
+          it('will return true', () => {
+            expect(errorUtilities.stackTraceHasValidDomain({
+              stack: [
+                {
+                  line: 1,
+                  column: 23,
+                  url: 'http://external.com/index.js',
+                  func: 'run'
+                },
+                {
+                  line: 2,
+                  column: 34,
+                  url: 'http://example.com/index.js',
+                  func: 'show'
+                },
+              ]
+            }, [])).toEqual(true);
+          });
+        });
+
+        describe('with all lines that have urls that match the current domain', () => {
+          it('will return true', () => {
+            expect(errorUtilities.stackTraceHasValidDomain({
+              stack: [
+                {
+                  line: 1,
+                  column: 23,
+                  url: 'http://example.com/index.js',
+                  func: 'run'
+                },
+                {
+                  line: 2,
+                  column: 34,
+                  url: 'http://example.com/index.js',
+                  func: 'show'
+                },
+              ]
+            }, [])).toEqual(true);
+          });
+        });
+      });
+
+      describe('with whitelisted domains', () => {
+        describe('with no line that has a url that matches the current domain', () => {
+          describe('no matches to the whitelist', () => {
+            it('will return false', () => {
+              expect(errorUtilities.stackTraceHasValidDomain({
+                stack: [
+                  {
+                    line: 1,
+                    column: 23,
+                    url: 'http://external.com/index.js',
+                    func: 'run'
+                  },
+                  {
+                    line: 2,
+                    column: 34,
+                    url: 'http://another.com/index.js',
+                    func: 'show'
+                  },
+                ]
+              }, ['api.raygun.com'])).toEqual(false);
+            });
+          });
+
+          describe('a match with an item in the whitelist', () => {
+            it('will return true', () => {
+              expect(errorUtilities.stackTraceHasValidDomain({
+                stack: [
+                  {
+                    line: 1,
+                    column: 23,
+                    url: 'http://external.com/index.js',
+                    func: 'run'
+                  },
+                  {
+                    line: 2,
+                    column: 34,
+                    url: 'http://another.com/index.js',
+                    func: 'show'
+                  },
+                ]
+              }, ['another.com'])).toEqual(true);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/raygun.utilities/errorUtilities.spec.js
+++ b/src/raygun.utilities/errorUtilities.spec.js
@@ -183,26 +183,26 @@ describe('Error utilities', () => {
     });
   });
 
-  describe('isInvalidStackTrace', () => {
+  describe('isValidStackTrace', () => {
     describe('with null stack array', () => {
-      it('will return true', () => {
-        expect(errorUtilities.isInvalidStackTrace({
+      it('will return false', () => {
+        expect(errorUtilities.isValidStackTrace({
           stack: null,
-        })).toEqual(true);
+        })).toEqual(false);
       });
     });
 
     describe('with empty stack array', () => {
-      it('will return true', () => {
-        expect(errorUtilities.isInvalidStackTrace({
+      it('will return false', () => {
+        expect(errorUtilities.isValidStackTrace({
           stack: [],
-        })).toEqual(true);
+        })).toEqual(false);
       });
     });
 
     describe('with all null values in stack lines', () => {
-      it('will return true', () => {
-        expect(errorUtilities.isInvalidStackTrace({
+      it('will return false', () => {
+        expect(errorUtilities.isValidStackTrace({
           stack: [
             {
               line: null,
@@ -211,13 +211,13 @@ describe('Error utilities', () => {
               func: '?'
             }
           ],
-        })).toEqual(true);
+        })).toEqual(false);
       });
     });
 
     describe('with known error from bot', () => {
-      it('will return true', () => {
-        expect(errorUtilities.isInvalidStackTrace({
+      it('will return false', () => {
+        expect(errorUtilities.isValidStackTrace({
           message: 'Object Not Found Matching Id:1',
           stack: [
             {
@@ -227,14 +227,14 @@ describe('Error utilities', () => {
               func: 'Z'
             }
           ],
-        })).toEqual(true);
+        })).toEqual(false);
       });
     });
 
     describe('with zero line and column numbers, function is "?"', () => {
       describe('with a url that matches the current location', () => {
-        it('will return true', () => {
-          expect(errorUtilities.isInvalidStackTrace({
+        it('will return false', () => {
+          expect(errorUtilities.isValidStackTrace({
             message: 'ResizeObserver loop limit exceeded',
             stack: [
               {
@@ -244,13 +244,13 @@ describe('Error utilities', () => {
                 func: '?'
               }
             ],
-          })).toEqual(true);
+          })).toEqual(false);
         });
       });
 
       describe('with a url that does not match the current location', () => {
         it('will return true', () => {
-          expect(errorUtilities.isInvalidStackTrace({
+          expect(errorUtilities.isValidStackTrace({
             message: 'TypeError: undefined is not a function',
             stack: [
               {
@@ -260,14 +260,14 @@ describe('Error utilities', () => {
                 func: '?'
               }
             ],
-          })).toEqual(false);
+          })).toEqual(true);
         });
       });
 
       describe('with valid stacktrace', () => {
         describe('with all valid stack lines', () => {
-          it('will return false', () => {
-            expect(errorUtilities.isInvalidStackTrace({
+          it('will return true', () => {
+            expect(errorUtilities.isValidStackTrace({
               message: 'Cannot read property \'fn\' of undefined',
               stack: [
                 {
@@ -283,13 +283,13 @@ describe('Error utilities', () => {
                   func: 'run'
                 },
               ],
-            })).toEqual(false);
+            })).toEqual(true);
           });
         });
 
         describe('with an invalid stack line', () => {
-          it('will return false', () => {
-            expect(errorUtilities.isInvalidStackTrace({
+          it('will return true', () => {
+            expect(errorUtilities.isValidStackTrace({
               message: 'Cannot read property \'fn\' of undefined',
               stack: [
                 {
@@ -305,7 +305,7 @@ describe('Error utilities', () => {
                   func: 'Z'
                 },
               ],
-            })).toEqual(false);
+            })).toEqual(true);
           });
         });
       });

--- a/src/raygun.utilities/errorUtilities.spec.js
+++ b/src/raygun.utilities/errorUtilities.spec.js
@@ -54,6 +54,29 @@ describe('Error utilities', () => {
         expect(errorUtilities.isScriptError(stackTrace, {})).toEqual(true);
       });
     });
+
+    describe('with an error that is not script error', () => {
+      it('will return false', () => {
+        const stackTrace = {
+          message: 'Cannot read property \'expand\' of undefined',
+          stack: [
+            {
+              line: 56,
+              column: 12,
+              url: 'http://example.com/index.js',
+              func: 'render'
+            },
+            {
+              line: 12,
+              column: 34,
+              url: 'http://example.com/index.js',
+              func: 'start'
+            },
+          ]
+        };
+        expect(errorUtilities.isScriptError(stackTrace, {})).toEqual(false);
+      });
+    });
   });
 
   describe('isBrowserExtensionError', () => {
@@ -67,7 +90,7 @@ describe('Error utilities', () => {
       });
     });
 
-    describe('with null url in stacktrace', () => {
+    describe('with undefined url in stacktrace', () => {
       it('will return false', () => {
         const stackTrace = {
           stack: [

--- a/src/raygun.utilities/index.js
+++ b/src/raygun.utilities/index.js
@@ -488,30 +488,6 @@ window.raygunUtilityFactory = function(window, Raygun) {
       }
 
       return false;
-    },
-
-    /**
-     * Given an array, invoke the predicate on each item in the array, for this to return true, all predicate calls must
-     * return true. Simplified version of {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every/|Array.prototype.every}.
-     *
-     * @param arr T[]
-     * @param predicate (item: T) => boolean
-     * @returns {boolean}
-     */
-    all: function all(arr, predicate) {
-      if (this.isEmpty(arr)) {
-        return false;
-      }
-
-      for (var i = 0; i < arr.length; i++) {
-        var item = arr[i];
-
-        if (predicate(item) === false) {
-          return false;
-        }
-      }
-
-      return true;
     }
   };
 

--- a/src/raygun.utilities/index.js
+++ b/src/raygun.utilities/index.js
@@ -170,13 +170,31 @@ window.raygunUtilityFactory = function(window, Raygun) {
       }
     },
 
-    isEmpty: function(o) {
+    isEmpty: function isEmpty(o) {
+      if (this.isNil(o)) {
+        return true;
+      }
+
+      if (typeof o === 'string' || o instanceof Array) {
+        return o.length === 0;
+      }
+
       for (var p in o) {
         if (o.hasOwnProperty(p)) {
           return false;
         }
       }
       return true;
+    },
+
+    /**
+     * Check if the object provided is either null or undefined
+     *
+     * @param obj
+     * @returns {boolean}
+     */
+    isNil: function isNil(obj) {
+      return typeof obj === 'undefined' || obj === null;
     },
 
     contains: function(array, obj) {
@@ -446,6 +464,54 @@ window.raygunUtilityFactory = function(window, Raygun) {
     },
     isIE: function() {
       return window.navigator.userAgent.indexOf('Trident') > -1 || window.navigator.userAgent.indexOf('MSIE') > -1;
+    },
+
+    /**
+     * Given an array, invoke the predicate on each item in the array, if any of these calls return true, then the
+     * result is true. Simplified version of {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some/|Array.prototype.some}.
+     *
+     * @param arr T[]
+     * @param predicate (item: T) => boolean
+     * @returns {boolean}
+     */
+    any: function any(arr, predicate) {
+      if (this.isEmpty(arr)) {
+        return false;
+      }
+
+      for (var i = 0; i < arr.length; i++) {
+        var item = arr[i];
+
+        if (predicate(item) === true) {
+          return true;
+        }
+      }
+
+      return false;
+    },
+
+    /**
+     * Given an array, invoke the predicate on each item in the array, for this to return true, all predicate calls must
+     * return true. Simplified version of {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every/|Array.prototype.every}.
+     *
+     * @param arr T[]
+     * @param predicate (item: T) => boolean
+     * @returns {boolean}
+     */
+    all: function all(arr, predicate) {
+      if (this.isEmpty(arr)) {
+        return false;
+      }
+
+      for (var i = 0; i < arr.length; i++) {
+        var item = arr[i];
+
+        if (predicate(item) === false) {
+          return false;
+        }
+      }
+
+      return true;
     }
   };
 

--- a/src/raygun.utilities/utilities.spec.js
+++ b/src/raygun.utilities/utilities.spec.js
@@ -48,7 +48,7 @@ describe("raygun.utilities", () => {
 
             global.__DEV__ = dev;
             global.document = document;
-            
+
             return () => {
                 global.__DEV__ = devBefore;
                 global.document = documentBefore;
@@ -62,7 +62,7 @@ describe("raygun.utilities", () => {
                 reset();
             });
         });
-        
+
         describe('with the document defined', () => {
             it('returns false', () => {
                 const reset = setGlobalNativeChecks(true, true);
@@ -70,7 +70,7 @@ describe("raygun.utilities", () => {
                 reset();
             });
         });
-        
+
         describe('with __DEV__ being undefined', () => {
             it('returns false', () => {
                 const reset = setGlobalNativeChecks(true, undefined);
@@ -108,14 +108,14 @@ describe("raygun.utilities", () => {
         });
 
         it("uses innerText if textContent is not defined", () => {
-            const node = jasmine.createSpyObj("node", [], { 
+            const node = jasmine.createSpyObj("node", [], {
                 'innerText': "Inner text"
             });
             expect(utils.nodeText(node)).toBe('Inner text');
         });
 
         it("uses textContent first", () => {
-            const node = jasmine.createSpyObj("node", [], { 
+            const node = jasmine.createSpyObj("node", [], {
                 'textContent': "Text content",
                 'innerText': "Inner text"
             });
@@ -129,7 +129,7 @@ describe("raygun.utilities", () => {
             ];
             nodes.forEach(nodeName => describe(`as ${nodeName}`, () => {
                 it('returns node.value when defined', () => {
-                    const node = jasmine.createSpyObj("node", [], { 
+                    const node = jasmine.createSpyObj("node", [], {
                         'textContent': "Text content",
                         'type': nodeName,
                         'value': "Node value"
@@ -138,7 +138,7 @@ describe("raygun.utilities", () => {
                 });
 
                 it('returns normal text when node.value is not defined', () => {
-                    const node = jasmine.createSpyObj("node", [], { 
+                    const node = jasmine.createSpyObj("node", [], {
                         'textContent': "Text content",
                         'type': nodeName,
                     });
@@ -168,12 +168,124 @@ describe("raygun.utilities", () => {
                 className: 'classNameOne classNameTwo'
             }, 'button#submit.classNameOne.classNameTwo']
         ];
-        
+
         nodeTypes.forEach((test, index) => describe(`with node#${index}`, () => {
             it(`returns ${test[1]}`, () => {
                 const node = jasmine.createSpyObj("node", [], test[0]);
                 expect(utils.nodeSelector(node)).toBe(test[1]);
             });
         }));
+    });
+
+    describe('isNil', () => {
+        describe('with multiple cases', () => {
+            let undefinedVar;
+            const obj = {};
+
+            const cases = [
+                [null, true],
+                [undefined, true],
+                [undefinedVar, true],
+                [obj.undefinedProp, true],
+                [NaN, false],
+                [0, false],
+                [false, false],
+                ['', false],
+                [[], false],
+                [{}, false],
+            ];
+
+            cases.forEach(currentCase => {
+                const [value, expected] = currentCase;
+                describe(`with value ${JSON.stringify(value)}`, () => {
+                    it(`will return ${expected}`, () => {
+                        expect(utils.isNil(value)).toEqual(expected);
+                    });
+                });
+            });
+        });
+    });
+
+    describe('isEmpty', () => {
+        describe('with multiple cases', () => {
+            const cases = [
+                [null, true],
+                [undefined, true],
+                [[], true],
+                ['', true],
+                [{}, true],
+                ['hello', false],
+                [[1, 2, 3], false],
+                [{a: 1}, false],
+            ];
+
+            cases.forEach(currentCase => {
+                const [value, expected] = currentCase;
+                describe(`with value ${JSON.stringify(value)}`, () => {
+                    it(`will return ${expected}`, () => {
+                        expect(utils.isEmpty(value)).toEqual(expected);
+                    });
+                });
+            });
+        });
+    });
+
+    describe('any', () => {
+        describe('with invalid array values', () => {
+            describe('with null value', () => {
+                it('will return false', () => {
+                    expect(utils.any(null, () => true)).toEqual(false);
+                });
+            });
+            describe('with empty array', () => {
+                it('will return false', () => {
+                    expect(utils.any([], () => true)).toEqual(false);
+                });
+            });
+        });
+        describe('with valid array values', () => {
+            describe('with array that has no items that match the predicate', () => {
+                it('will return false', () => {
+                    expect(utils.any([1, 1, 2, 3, 5, 8], (item) => item > 8)).toEqual(false);
+                });
+            });
+            describe('with array that has an item that matches the predicate', () => {
+                it('will return true', () => {
+                    expect(utils.any([1, 2, 4, 8, 16], (item) => item > 8)).toEqual(true);
+                });
+            });
+        });
+    });
+
+    describe('all', () => {
+        describe('with invalid array values', () => {
+            describe('with null value', () => {
+                it('will return false', () => {
+                    expect(utils.all(null, () => true)).toEqual(false);
+                });
+            });
+            describe('with empty array', () => {
+                it('will return false', () => {
+                    expect(utils.all([], () => true)).toEqual(false);
+                });
+            });
+        });
+        describe('with valid array values', () => {
+            describe('with array that has no items that match the predicate', () => {
+                it('will return false', () => {
+                    expect(utils.all([1, 1, 2, 3, 5, 8, 13, 21], (item) => item > 22)).toEqual(false);
+                });
+            });
+            describe('with array that has only some items that match the predicate', () => {
+                it('will return false', () => {
+                    expect(utils.all([1, 1, 2, 3, 5, 8, 13, 21], (item) => item > 8)).toEqual(false);
+                });
+            });
+            describe('with array where all items match the predicate', () => {
+                it('will return true', () => {
+                    expect(utils.all([2, 4, 6, 8, 12], (item) => item % 2 === 0)).toEqual(true);
+                });
+            });
+        });
     });
 });

--- a/src/raygun.utilities/utilities.spec.js
+++ b/src/raygun.utilities/utilities.spec.js
@@ -237,6 +237,7 @@ describe("raygun.utilities", () => {
                     expect(utils.any(null, () => true)).toEqual(false);
                 });
             });
+
             describe('with empty array', () => {
                 it('will return false', () => {
                     expect(utils.any([], () => true)).toEqual(false);
@@ -249,41 +250,10 @@ describe("raygun.utilities", () => {
                     expect(utils.any([1, 1, 2, 3, 5, 8], (item) => item > 8)).toEqual(false);
                 });
             });
+
             describe('with array that has an item that matches the predicate', () => {
                 it('will return true', () => {
                     expect(utils.any([1, 2, 4, 8, 16], (item) => item > 8)).toEqual(true);
-                });
-            });
-        });
-    });
-
-    describe('all', () => {
-        describe('with invalid array values', () => {
-            describe('with null value', () => {
-                it('will return false', () => {
-                    expect(utils.all(null, () => true)).toEqual(false);
-                });
-            });
-            describe('with empty array', () => {
-                it('will return false', () => {
-                    expect(utils.all([], () => true)).toEqual(false);
-                });
-            });
-        });
-        describe('with valid array values', () => {
-            describe('with array that has no items that match the predicate', () => {
-                it('will return false', () => {
-                    expect(utils.all([1, 1, 2, 3, 5, 8, 13, 21], (item) => item > 22)).toEqual(false);
-                });
-            });
-            describe('with array that has only some items that match the predicate', () => {
-                it('will return false', () => {
-                    expect(utils.all([1, 1, 2, 3, 5, 8, 13, 21], (item) => item > 8)).toEqual(false);
-                });
-            });
-            describe('with array where all items match the predicate', () => {
-                it('will return true', () => {
-                    expect(utils.all([2, 4, 6, 8, 12], (item) => item % 2 === 0)).toEqual(true);
                 });
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,17 +773,16 @@ chrome-launcher@^0.13.1:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chromedriver@^88.0.0:
-  version "88.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-88.0.0.tgz#6833fffd516db23c811eeafa1ee1069b5a12fd2f"
-  integrity sha512-EE8rXh7mikxk3VWKjUsz0KCUX8d3HkQ4HgMNJhWrWjzju12dKPPVHO9MY+YaAI5ryXrXGNf0Y4HcNKgW36P/CA==
+chromedriver@^92.0.1:
+  version "92.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-92.0.1.tgz#3e28b7e0c9fb94d693cf74d51af0c29d57f18dca"
+  integrity sha512-LptlDVCs1GgyFNVbRoHzzy948JDVzTgGiVPXjNj385qXKQP3hjAVBIgyvb/Hco0xSEW8fjwJfsm1eQRmu6t4pQ==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
-    mkdirp "^1.0.4"
     proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.1"
 
@@ -2528,7 +2527,7 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.4, mkdirp@~1.0.3:
+mkdirp@~1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==


### PR DESCRIPTION
## Overview

If an error occurs in a script that is injected into the body of the website's document by an extension, this error can be caught by the `window.onerror` handler. 

From researching this, I've found errors from browser extensions can take on multiple forms. This PR covers three particular cases, with the aim that if a developer wants to ignore third-party errors, these errors should also be ignored.

If the error occurs within a function, then each line of the stacktrace will have a `url` value prefixed with `*-extension://` (where `*` is one of 'chrome', 'safari', 'safari-web', or 'moz').

For example:

```js
{
  message: 'Error in a browser extension function',
  stack: [
    {
      line: 12,
      column: 345,
      url: 'chrome-extension://example/index.js',
      func: 'render'
    },
  ]
}
```

There is now a utility function for detecting browser extension errors like this. This function could be used for specifically ignoring errors from browser extensions in future.

An error can occur directly in an injected script, this can lead to a stacktrace with null values like so:

```js
{
  message: 'Error in a browser extension script',
  stack: [
    {
      line: null,
      column: null,
      url: null,
      func: 'onLoadHandler'
    },
  ]
}
```

I've observed another more obscure case, where the `url` is set to the current website's URL, and the `func` is '?'.

```js
{
  message: 'Error from a browser extension, bot or crawler',
  stack: [
    {
      line: 0,
      column: 0,
      url: 'http://example.com/index.html',
      func: '?'
    },
  ]
}
```

There's a utility function to detect if a stacktrace matches this pattern, and the error will be discarded if every line in the stacktrace matches.

## Updates

- Add a new error utility script with functions for detecting various types of error
- Move some of the existing logic to the utility script for easier unit testing
- Extact the `ignore3rdPartyErrors` logic out into a separate function 
- Add helper utilities for various common functions