### PR TITLE
Github Action - Deploy to pre-release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,8 +2,9 @@ name: Build & Publish Raygun4JS to the pre-release environment
 
 on:
   push:
-    branches: [ master ]
-
+    branches: [ master ]  
+  workflow_dispatch:
+  
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a Github action that will trigger when master is updated. This will deploy the provider to our pre-release environment.