### PR TITLE
(Bugfix) Resolve issue where calling originalFetch can throw an unhandled rejection.

### DIFF
--- a/src/raygun.network-tracking.js
+++ b/src/raygun.network-tracking.js
@@ -217,9 +217,7 @@ window.raygunNetworkTrackingFactory = function(window, Raygun) {
                 executeHandlers();
               }
             })
-          );
-
-          promise.catch(
+          ).catch(
             self.wrapWithHandler(function(error) {
               self.executeHandlers(self.errorHandlers, {
                 metadata: {


### PR DESCRIPTION
This PR does the same change as #375 but I already made the change before noticing this PR and have some explanation around the fix 😅 

Currently the existing code for `processFetch` calls `originalFetch` and stores the promise, it then attempts to attach a chain to the original promise to fork the promise resolution for raygun specific handling of things. This is fine except the `catch` is attached to the parent promise instead of the new `then` chain which has been added to the original promise. 

This consequently means that if the newly attached `then` chain throws an exception it is not handled.

Original flow:
```
            ┌──────────────┐
            │ processFetch │
            └───────┬──────┘
                    │
                    ▼
┌─────────────────────────────────┐
│                                 │
│           ┌───────────────┐     │
│           │ originalFetch │     │
│           └───────┬───────┘     │
│                   │             │
│                   ▼             │
│              ┌─────────┐        │
│              │ promise │        │
│              └─┬──┬──┬─┘        │
│                │  │  │          │
│     ┌──────────┘  │  └──────┐   │
│     ▼             ▼         │   │
│ ┌──────┐      ┌───────┐     │   │
│ │ then │      │ catch │     │   │
│ └───┬──┘      └───────┘     │   │
│     │                       │   │
└─────┼───────────────────────┼───┘
      │                       │
   throws                  returns
      │                       │
      │                       ▼
      ▼                  ┌─────────┐
┌───────────┐            │ promise │
│ Unhandled │            └─────────┘
│           │
│ Rejection │
└───────────┘
```

This small change attaches the `catch` to the new `then` and handles throw errors as what appears to be the original intention of the code:

```
            ┌──────────────┐
            │ processFetch │
            └───────┬──────┘
                    │
                    ▼
┌─────────────────────────────────┐
│                                 │
│           ┌───────────────┐     │
│           │ originalFetch │     │
│           └───────┬───────┘     │
│                   │             │
│                   ▼             │
│              ┌─────────┐        │
│              │ promise │        │
│              └─┬─────┬─┘        │
│                │     │          │
│              ┌─┘     │          │
│              │       │          │
│              ▼       │          │
│          ┌──────┐    │          │
│          │ then │    │          │
│          └───┬──┘    │          │
│              │       │          │
│              ▼       │          │
│          ┌───────┐   │          │
│          │ catch │   │          │
│          └───────┘   │          │
│                      │          │
└──────────────────────┼──────────┘
                       │
                    returns
                       │
                       ▼
                  ┌─────────┐
                  │ promise │
                  └─────────┘

```

There are a number of other small oddities I noticed when tracking this down in this prototype that I will submit another PR for as they are not related to this immediate fix.

Fixes #430 
Fixes fetch calls throwing outside of their calling try/catch #366