### PR TITLE
Fix rg4js returning undefined when using UMD

### DIFF
--- a/src/umd.intro.js
+++ b/src/umd.intro.js
@@ -42,7 +42,7 @@
         (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
       } else {
         // onload has been called and provider has executed, call the executor proxy function
-        wind[wind['RaygunObject']](arguments[0], arguments[1]);
+        return wind[wind['RaygunObject']](arguments[0], arguments[1]);
       }
       
   }})(windw);


### PR DESCRIPTION
The rg4js proxy in the umd loader is currently throwing away the return value of the executor. This prevents the use of commands like 'getRaygunInstance'.