### PR TITLE
Support for Ionic Capacitor stack traces on iOS

### DIFF
--- a/tracekit/tracekit.js
+++ b/tracekit/tracekit.js
@@ -644,8 +644,8 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             return null;
         }
 
-        var chrome = /^\s*at (.*?) ?\(((?:file|https?|\s*|blob|chrome-extension|native|webpack|ionic|app|eval|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|ionic|app|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i,
+        var chrome = /^\s*at (.*?) ?\(((?:file|https?|\s*|blob|chrome-extension|native|webpack|ionic|capacitor|app|eval|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|ionic|capacitor|app|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],


### PR DESCRIPTION
Ionic Capacitor now uses the `capacitor://` scheme on iOS which is not included in the regex check which results in stack traces not being parsed correctly on iOS. I have added `capacitor` to the regex and verified that the stack traces are parsed correctly. Here is what the stack looks like on errors thrown from within Capacitor on iOS for reference:

```
cause: – undefined
message: – "Testing"
name: – "Error"
stack: – "Jn@capacitor://localhost/js/index.20.1d828c7a.js:1:134788↵global code@↵evaluateWithScopeExtension@[native code]↵@↵_wrapCall@" (chunk-vendors.20.242c3e64.js, line 3544)
"Jn@capacitor://localhost/js/index.20.1d828c7a.js:1:134788
global code@
evaluateWithScopeExtension@[native code]
@
_wrapCall@"
```

Here is also a link to the project on GitHub showing the official default value:
https://github.com/ionic-team/capacitor/blob/2b7016f3b4d62fd8c9d03fde2745b3d515bf08b2/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m#L10