### PR TITLE
Update Angular documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,8 +761,6 @@ export class RaygunErrorHandler implements ErrorHandler {
 }
 ```
 
-For more information, see the official docs under [Interceptors].
-
 ## Vue.js
 
 You can use the Vue.js error handler to send errors directly to Raygun.

--- a/README.md
+++ b/README.md
@@ -746,33 +746,22 @@ In Chrome, if the origin script tag and remote domain do not meet these requirem
 
 Other browsers may send on a best-effort basis (version dependent) if some data is available but potentially without a useful stacktrace. The provider will cancel the send if no data is available.
 
-## AngularJS
+## Angular
 
-You can hook failed Ajax requests with $http in AngularJS by providing an Interceptor that sends to Raygun on error. One possible simple implementation using custom data:
+You can extend the Angular error handler to send errors directly to Raygun.
 
-```javascript
-$httpProvider.interceptors.push(function($q, dependency1, dependency2) {
-  return {
-   'requestError': function(rejection) {
-       rg4js('send', {
-          error: 'Failed $http request',
-          customData: { rejection: rejection }
-       });
-    },
-
-    'responseError': function(rejection) {
-       rg4js('send', {
-          error: 'Failed $http response',
-          customData: { rejection: rejection}
-       });
-    }
-  };
-});
+```typescript
+// Create a new ErrorHandler and report an issue straight to Raygun
+export class RaygunErrorHandler implements ErrorHandler {
+  handleError(e: any) {
+    rg4js('send', {
+      error: e,
+    });
+  }
+}
 ```
 
 For more information, see the official docs under [Interceptors].
-
-[Interceptors]: https://docs.angularjs.org/api/ng/service/$http
 
 ## Vue.js
 

--- a/README.md
+++ b/README.md
@@ -259,15 +259,23 @@ $(window).hashchange(function() {
 });
 ```
 
-**AngularJS**
+**Angular**
 
-```javascript
-$scope.$on('$routeChangeSuccess', function () {
-  rg4js('trackEvent', {
-      type: 'pageView',
-      path: '/' + $scope.area
-  });
-});
+```typescript
+export class AppModule implements OnInit {
+  constructor(private router: Router) {}
+  ngOnInit() {
+    this.router.events.subscribe(event => {
+      // Track page views when the NavigationEnd event occurs
+      if (event instanceof NavigationEnd) {
+        rg4js('trackEvent', {
+          type: 'pageView',
+          path: event.url
+        });
+      }
+    });
+  }
+}
 ```
 
 #### Tracking custom timings


### PR DESCRIPTION
This PR is to update the raygun4js README to replace documentation for AngularJS (which has reached its EOL in Jan 2022) with relevant documentation for Angular 2+ (more commonly known as just "Angular")