### PR TITLE
Remove allowInsecureSubmissions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.26.0
+- Removed some dead code related to http support in IE8. As IE8 and http is [no longer supported due to security reasons](https://raygun.com/documentation/product-guides/crash-reporting/troubleshooting/#transport-layer-security-tls-compliance)
+  
 * v2.25.8
 - Improve README documentation to be more clear on the protocol relative URL and how to use the CDN implemmentation without running a server .
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ No installation via a package manager is required. Just add the following snippe
 The above snippet will fetch the Raygun4JS script from our CDN asynchronously, so it doesn't block other scripts from being loaded. It will also catch errors that are thrown while the page is loading, and send them when the script is ready.
 
 
+**Note:** If you encounter a situation where no events are appearing within Raygun, you may need to hard code the URL protocol so that the CDN matches your hosting environment. This could look like one of the following -
+- `https://cdn.raygun.io/raygun4js/raygun.min.js` 
+- `http://cdn.raygun.io/raygun4js/raygun.min.js` 
+
+This will be in replacement of `//cdn.raygun.io/raygun4js/raygun.min.js`.
+
 ### Via package manager installation 
 For installations and usage via a package manager, refer to the [Synchronous methods](#synchronous-methods) section of this document.
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ No installation via a package manager is required. Just add the following snippe
 The above snippet will fetch the Raygun4JS script from our CDN asynchronously, so it doesn't block other scripts from being loaded. It will also catch errors that are thrown while the page is loading, and send them when the script is ready.
 
 
-**Note:** If you encounter a situation where no events are appearing within Raygun, you may need to hard code the URL protocol so that the CDN matches your hosting environment. This could look like one of the following -
-- `https://cdn.raygun.io/raygun4js/raygun.min.js` 
-- `http://cdn.raygun.io/raygun4js/raygun.min.js` 
-
-This will be in replacement of `//cdn.raygun.io/raygun4js/raygun.min.js`.
-
 ### Via package manager installation 
 For installations and usage via a package manager, refer to the [Synchronous methods](#synchronous-methods) section of this document.
 

--- a/README.md
+++ b/README.md
@@ -143,17 +143,6 @@ If you need to detach it (this will disable automatic unhandled error sending):
 rg4js('detach');
 ```
 
-**IE8**
-
-If you are serving your site over HTTP and want IE8 to be able to submit JavaScript errors then you will
-need to set the following setting which will allow IE8 to submit the error over HTTP. Otherwise the provider
-will only submit over HTTPS which IE8 will not allow while being served over HTTP.
-
-```javascript
-rg4js('options', {
-  allowInsecureSubmissions: true
-});
-```
 
 ## Documentation
 
@@ -168,8 +157,6 @@ rg4js('options', {
 ```
 
 The second parameter should contain one or more of these keys and a value to customize the behavior:
-
-`allowInsecureSubmissions` - posts error payloads over HTTP. This allows **IE8** to send JS errors
 
 `ignoreAjaxAbort` - User-aborted Ajax calls result in errors - if this option is true, these will not be sent.
 
@@ -219,7 +206,6 @@ An example raygun4js configuration:
 
 ```javascript
 rg4js('options', {
-  allowInsecureSubmissions: true,
   ignoreAjaxAbort: true,
   ignoreAjaxError: true,
   debugMode: true,

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.25.8",
+  "version": "2.26.0",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.25.8",
+  "version": "2.26.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.25.8</version>
+    <version>2.26.0</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -34,7 +34,6 @@ var raygunFactory = function(window, $, undefined) {
   var _traceKit = TraceKit,
     _raygun = window.Raygun,
     _debugMode = false,
-    _allowInsecureSubmissions = false,
     _ignoreAjaxAbort = false,
     _ignoreAjaxError = false,
     _enableOfflineSave = false,
@@ -112,7 +111,6 @@ var raygunFactory = function(window, $, undefined) {
       }
 
       if (options) {
-        _allowInsecureSubmissions = options.allowInsecureSubmissions || false;
         _ignoreAjaxAbort = options.ignoreAjaxAbort || false;
         _ignoreAjaxError = options.ignoreAjaxError || false;
         _disableAnonymousUserTracking = options.disableAnonymousUserTracking || false;
@@ -976,21 +974,13 @@ var raygunFactory = function(window, $, undefined) {
       // XHR for Chrome/Firefox/Opera/Safari
       // as well as React Native's custom XHR implementation
       xhr.open(method, url, true);
-    } else if (window.XDomainRequest) {
-      // XDomainRequest for IE.
-      if (_allowInsecureSubmissions) {
-        // remove 'https:' and use relative protocol
-        // this allows IE8 to post messages when running
-        // on http
-        url = url.slice(6);
-      }
-
+    } 
+    else if (window.XDomainRequest) {
       xhr = new window.XDomainRequest();
       xhr.open(method, url);
     }
 
     xhr.timeout = 10000;
-
     return xhr;
   }
 

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -966,21 +966,15 @@ var raygunFactory = function(window, $, undefined) {
 
   // Create the XHR object.
   function createCORSRequest(method, url) {
-    var xhr;
-
-    xhr = new window.XMLHttpRequest();
+    var xhr = new window.XMLHttpRequest();
+    xhr.timeout = 10000;
 
     if ('withCredentials' in xhr || Raygun.Utilities.isReactNative()) {
       // XHR for Chrome/Firefox/Opera/Safari
       // as well as React Native's custom XHR implementation
       xhr.open(method, url, true);
-    } 
-    else if (window.XDomainRequest) {
-      xhr = new window.XDomainRequest();
-      xhr.open(method, url);
-    }
+    }     
 
-    xhr.timeout = 10000;
     return xhr;
   }
 

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -1327,7 +1327,7 @@ var raygunRumFactory = function (window, $, Raygun) {
       return (
         initiatorType === 'xmlhttprequest' ||
         initiatorType === 'fetch' ||
-        initiatorType === 'preflight' || // 'preflight' initatorType used by Edge for CORS POST/DELETE requests
+        initiatorType === 'preflight' || // 'preflight' initiatorType used by Edge for CORS POST/DELETE requests
         initiatorType === 'beacon' // for navigator.sendBeacon calls in Chrome/Edge. Safari doesn't record the timings and Firefox marks them as 'other'
       );
     }


### PR DESCRIPTION
The `allowInsecureSubmissions` option was necessary to enable http (not s) support on IE8

We no longer support IE8, also IE 8 doesn't support TLS 1.2 

So this functionality is obsolete and needs to be removed
(Removal from the docs is in another PR)

Also removed code for `XDocumentRequest` as this is also (very) obsolete  