### PR TITLE
Implement fixes in Raygun4JS to correctly handle XHRs and virtual pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v2.26.1
+- Fixed timing bug, where rarely some xhr requests may miss attributed to a different page from which they were started on. Updated unit test libraries and re-enabled running on PR creation
+
 * v2.26.0
 - Removed some dead code related to http support in IE8. As IE8 and http is [no longer supported due to security reasons](https://raygun.com/documentation/product-guides/crash-reporting/troubleshooting/#transport-layer-security-tls-compliance)
   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "homepage": "http://raygun.io",
   "authors": [
     "Mindscape <hello@raygun.io>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.26.0</version>
+    <version>2.26.1</version>
     <title>Raygun4js</title>
     <authors>Mindscape Limited</authors>
     <owners>Mindscape Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -563,7 +563,7 @@ var raygunRumFactory = function (window, $, Raygun) {
 
         self.offset = i;
 
-        if (this._captureMissingRequests) {
+        if (self._captureMissingRequests) {
           addMissingWrtData(collection, offset);
         }
       } catch (e) {
@@ -1028,7 +1028,7 @@ var raygunRumFactory = function (window, $, Raygun) {
 
     function attachParentResource(obj, parentResource) {
       if (parentResource) {
-        return Raygun.Utilities.merge(obj, { parentResource: parentResource });
+        return Raygun.Utilities.merge({ parentResource: parentResource }, obj);
       }
 
       return obj;


### PR DESCRIPTION
This PR fixes:
 1. A bug where under some rare race conditions xhr requests get attributed to a different parent resource (page url)