### PR TITLE
Update endpoint from .io to .com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Replaced old company name
+- Documentation points to 'new' url
+
+### Changed
+
+- Updated the Raygun url to send events to preferred ingestion endpoint
+
 ## v2.26.1 - 2023-07-12
 
 ### Fixed

--- a/V1Documentation.md
+++ b/V1Documentation.md
@@ -476,7 +476,7 @@ Raygun.setFilterScope('customData'); // Just filter the custom data (default)
 
 Raygun4JS now features source maps support through the transmission of column numbers for errors, where available. This is confirmed to work in recent version of Chrome, Safari and Opera, and IE 10 and 11. See the [Raygun souce maps documentation][sourcemaps] for more information.
 
-[sourcemaps]: https://raygun.io/docs/workflow/source-maps
+[sourcemaps]: https://raygun.com/docs/workflow/source-maps
 
 ### Offline saving
 
@@ -549,7 +549,7 @@ Due to browser API and security limitations, in cases where the message is 'Scri
 
 For more information, check out this blog post on [CORS requirements for Script Errors].
 
-[CORS requirements for Script Errors]: https://raygun.io/blog/2015/05/fix-script-error-and-get-the-most-data-possible-from-cross-domain-js-errors/
+[CORS requirements for Script Errors]: https://raygun.com/blog/2015/05/fix-script-error-and-get-the-most-data-possible-from-cross-domain-js-errors/
 
 ## AngularJS
 

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,15 @@
 {
   "name": "raygun4js",
   "version": "2.26.1",
-  "homepage": "http://raygun.io",
+  "homepage": "http://raygun.com",
   "authors": [
-    "Mindscape <hello@raygun.io>"
+    "Mindscape <hello@raygun.com>"
   ],
   "repository": {
     "type": "git",
     "url": "git://github.com/MindscapeHQ/raygun4js.git"
   },
-  "description": "Official Raygun.io automatic error tracking plugin for JavaScript",
+  "description": "Official Raygun.com automatic error tracking plugin for JavaScript",
   "main": "dist/raygun.js",
   "keywords": [
     "error",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun4js",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun4js",
-      "version": "2.26.1",
+      "version": "2.26.2",
       "license": "SEE LICENSE IN https://github.com/MindscapeHQ/raygun4js/blob/master/LICENSE",
       "devDependencies": {
         "@wdio/cli": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.26.1</version>
+    <version>2.26.2</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -4,15 +4,15 @@
     <id>raygun4js</id>
     <version>2.26.1</version>
     <title>Raygun4js</title>
-    <authors>Mindscape Limited</authors>
-    <owners>Mindscape Limited</owners>
+    <authors>Raygun Limited</authors>
+    <owners>Raygun Limited</owners>
     <licenseUrl>https://raw2.github.com/MindscapeHQ/raygun4js/master/LICENSE</licenseUrl>
-    <projectUrl>http://raygun.io/raygun-providers/javascript</projectUrl>
+    <projectUrl>http://raygun.com/raygun-providers/javascript</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>Official Raygun JavaScript module - automatic client-side error tracking for your web project</summary>
-    <description>Raygun4js is a tiny library that you can easily add to your website or web application, which will then let your site automatically transmit all Errors to your Raygun.io dashboard, where you can see the stack trace, environment data, custom data and more. Installation is painless, and configuring your site to transmit errors takes just a couple of minutes.</description>
+    <summary>Official Raygun JavaScript module - automatic client-side error tracking and Real User Monitoring for your web project</summary>
+    <description>Raygun4js is a tiny library that you can easily add to your website or web application, which will then let your site automatically transmit all Errors to your Raygun.com dashboard, where you can see the stack trace, environment data, custom data and more. Installation is painless, and configuring your site to transmit errors takes just a couple of minutes.</description>
     <language>en-US</language>
-    <tags>raygun error tracking reporting logging</tags>
+    <tags>raygun error tracking reporting logging monitoring</tags>
   </metadata>
 
   <files>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -56,7 +56,7 @@ var raygunFactory = function(window, $, undefined) {
     _groupingKeyCallback,
     _beforeXHRCallback,
     _afterSendCallback,
-    _raygunApiUrl = 'https://api.raygun.io',
+    _raygunApiUrl = 'https://api.raygun.com',
     _excludedHostnames = null,
     _excludedUserAgents = null,
     _filterScope = 'customData',

--- a/tests/specs/v1/eventsXhr.js
+++ b/tests/specs/v1/eventsXhr.js
@@ -2,7 +2,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe("XHR functional tests for /events with V1", function() {
 

--- a/tests/specs/v1/payloadManualSendTests.js
+++ b/tests/specs/v1/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V1 manual send", function() {
 

--- a/tests/specs/v1/payloadUnhandledErrorTests.js
+++ b/tests/specs/v1/payloadUnhandledErrorTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V1 automatic unhandled error sending", function() {
 

--- a/tests/specs/v2/eventsXhr.js
+++ b/tests/specs/v2/eventsXhr.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe("XHR functional tests for /events with V2", function() {
 

--- a/tests/specs/v2/onBeforeSendRUM.js
+++ b/tests/specs/v2/onBeforeSendRUM.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.io/events';
+var _eventsEndpoint = 'https://api.raygun.com/events';
 
 describe('onBeforeSendRUM callback', function() {
   it('lets you modify the payload before sending', async function() {

--- a/tests/specs/v2/payloadManualSendTests.js
+++ b/tests/specs/v2/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V2 manual send", function() {
 

--- a/tests/specs/v2/payloadSyntaxError.js
+++ b/tests/specs/v2/payloadSyntaxError.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for V2 syntax error caught with the Snippet", function() {
 

--- a/tests/specs/v2/payloadUnhandledErrorTests.js
+++ b/tests/specs/v2/payloadUnhandledErrorTests.js
@@ -2,7 +2,7 @@ var webdriverio = require('webdriverio');
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Payload functional validation tests for v2 automatic unhandled error sending", function() {
 

--- a/tests/specs/v2/rg4jsLoaderTests.js
+++ b/tests/specs/v2/rg4jsLoaderTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.io/entries';
+var _entriesEndpoint = 'https://api.raygun.com/entries';
 
 describe("Functional tests for rg4js() calls to ensure they are executed by the loader", function() {
 


### PR DESCRIPTION
Based off this:
https://github.com/MindscapeHQ/raygun4js/pull/349
[I was unable tp push a rebase from master to that PR/branch]

> This PR changes the default endpoint from api.raygun.io to api.raygun.com as .com is now the recommended endpoint.

https://github.com/MindscapeHQ/raygun4js/pull/349#issue-576533611

