### PR TITLE
Revert the default endpoint url from api.raygun.com back to api.raygun.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
+
+## v2.26.4
+
+
+### Fixed
+
+- Reverted the default endpoint url from api.raygun.com back to api.raygun.io (From release v2.26.2 which is causing disruptions for some users)
+
+
 ## v2.26.3
 
 ### Changed

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun4js",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun4js",
-      "version": "2.26.2",
+      "version": "2.26.4",
       "license": "SEE LICENSE IN https://github.com/MindscapeHQ/raygun4js/blob/master/LICENSE",
       "devDependencies": {
         "@wdio/cli": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.26.3</version>
+    <version>2.26.4</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -56,7 +56,7 @@ var raygunFactory = function(window, $, undefined) {
     _groupingKeyCallback,
     _beforeXHRCallback,
     _afterSendCallback,
-    _raygunApiUrl = 'https://api.raygun.com',
+    _raygunApiUrl = 'https://api.raygun.io',
     _excludedHostnames = null,
     _excludedUserAgents = null,
     _filterScope = 'customData',

--- a/src/raygun.utilities/errorUtilities.spec.js
+++ b/src/raygun.utilities/errorUtilities.spec.js
@@ -415,7 +415,7 @@ describe('Error utilities', () => {
                     func: 'show'
                   },
                 ]
-              }, ['api.raygun.com'])).toEqual(false);
+              }, ['api.raygun.io'])).toEqual(false);
             });
           });
 

--- a/tests/specs/v1/eventsXhr.js
+++ b/tests/specs/v1/eventsXhr.js
@@ -2,7 +2,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _eventsEndpoint = 'https://api.raygun.com/events';
+var _eventsEndpoint = 'https://api.raygun.io/events';
 
 describe("XHR functional tests for /events with V1", function() {
 

--- a/tests/specs/v1/payloadManualSendTests.js
+++ b/tests/specs/v1/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Payload functional validation tests for V1 manual send", function() {
 

--- a/tests/specs/v1/payloadUnhandledErrorTests.js
+++ b/tests/specs/v1/payloadUnhandledErrorTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Payload functional validation tests for V1 automatic unhandled error sending", function() {
 

--- a/tests/specs/v2/eventsXhr.js
+++ b/tests/specs/v2/eventsXhr.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.com/events';
+var _eventsEndpoint = 'https://api.raygun.io/events';
 
 describe("XHR functional tests for /events with V2", function() {
 

--- a/tests/specs/v2/onBeforeSendRUM.js
+++ b/tests/specs/v2/onBeforeSendRUM.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _eventsEndpoint = 'https://api.raygun.com/events';
+var _eventsEndpoint = 'https://api.raygun.io/events';
 
 describe('onBeforeSendRUM callback', function() {
   it('lets you modify the payload before sending', async function() {

--- a/tests/specs/v2/payloadManualSendTests.js
+++ b/tests/specs/v2/payloadManualSendTests.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Payload functional validation tests for V2 manual send", function() {
 

--- a/tests/specs/v2/payloadSyntaxError.js
+++ b/tests/specs/v2/payloadSyntaxError.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Payload functional validation tests for V2 syntax error caught with the Snippet", function() {
 

--- a/tests/specs/v2/payloadUnhandledErrorTests.js
+++ b/tests/specs/v2/payloadUnhandledErrorTests.js
@@ -2,7 +2,7 @@ var webdriverio = require('webdriverio');
 var _ = require('underscore');
 var common = require('../common');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Payload functional validation tests for v2 automatic unhandled error sending", function() {
 

--- a/tests/specs/v2/rg4jsLoaderTests.js
+++ b/tests/specs/v2/rg4jsLoaderTests.js
@@ -1,7 +1,7 @@
 var webdriverio = require('webdriverio');
 var _ = require('underscore');
 
-var _entriesEndpoint = 'https://api.raygun.com/entries';
+var _entriesEndpoint = 'https://api.raygun.io/entries';
 
 describe("Functional tests for rg4js() calls to ensure they are executed by the loader", function() {
 


### PR DESCRIPTION
- Reverted the default endpoint url from api.raygun.com back to api.raygun.io (From release v2.26.2 which is causing disruptions for some users)