### PR TITLE
Force .io if URL is not overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use api.raygun.io endpoint to send stored errors
+- Use api.raygun.io endpoint, if URL is not overridden, to send stored events
 
 
 ## v2.26.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## v2.26.5
+
+
+### Changed
+
+- Use api.raygun.io endpoint to send stored errors
+
+
 ## v2.26.4
 
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.26.4</version>
+    <version>2.26.5</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -74,7 +74,8 @@ var raygunFactory = function(window, $, undefined) {
     _setCookieAsSecure = false,
     _clientIp,
     _captureMissingRequests = false,
-    detachPromiseRejectionFunction;
+    detachPromiseRejectionFunction,
+    _customEndpointSet = false;
 
   var rand = Math.random();
   var _publicRaygunFunctions = {
@@ -129,6 +130,7 @@ var raygunFactory = function(window, $, undefined) {
 
         if (options.apiUrl) {
           _raygunApiUrl = options.apiUrl;
+          _customEndpointSet = true;
         }
 
         if (typeof options.wrapAsynchronousCallbacks !== 'undefined') {
@@ -150,6 +152,7 @@ var raygunFactory = function(window, $, undefined) {
 
         if (options.apiEndpoint) {
           _raygunApiUrl = options.apiEndpoint;
+          _customEndpointSet = true;
         }
 
         if (options.from) {
@@ -585,6 +588,12 @@ var raygunFactory = function(window, $, undefined) {
         if (key.indexOf('raygunjs+' + Raygun.Options._raygunApiKey) > -1) {
           try {
             var payload = JSON.parse(localStorage[key]);
+
+          // If the url contains 'raygun.com', replace it with 'raygun.io', but only if not custom set already (proxy, testing, etc)
+          if (!_customEndpointSet && payload.url.includes('raygun.com')) {
+            payload.url = payload.url.replace('raygun.com', 'raygun.io');
+          }
+
             makePostCorsRequest(payload.url, payload.data);
           } catch (e) {
             Raygun.Utilities.log('Raygun4JS: Invalid JSON object in LocalStorage');


### PR DESCRIPTION
This change forces the re-sending of stored errors to use the .IO domain name, rather than .COM. Due to the recent issue of changing this, some stored errors are being sent and causing further CSP violations.

This change is to address that issue.