### PR TITLE
Addclient info to rum payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unused normalize.css file
   
 -->
+## [2.28.0]
+
+### Changed
+
+- Adds client provider (version) information
+- Adds defaults for timing information payload information
+
 ## [2.27.3]
 
 ### Changed
@@ -43,14 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rolls back the previous change
 
 
-
-## [2.28.0]
-
-### Changed
-
-- Rolls back the previous change which causes issues for typescript users
-- Adds client provider (version) information
-- Adds defaults for timing information payload information
 
 ## [2.27.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rolls back the previous change
 
 
+
+## [2.27.2]
+
+### Changed
+
+- Rolls back the previous change which causes issues for typescript users
+- Adds client provider (version) information
+- Adds defaults for timing information payload information
+
 ## [2.27.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [2.27.2]
+## [2.28.0]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds client provider (version) information
 - Adds defaults for timing information payload information
 
+
 ## [2.27.3]
 
 ### Changed
@@ -42,13 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a rare condition with UMD where we assume rg4js is initialised but it is not, causing an infinite loop.
 
 
-
 ## [2.27.2]
 
 ### Changed
 
 - Rolls back the previous change
-
 
 
 ## [2.27.1]

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.27.3",
+  "version": "2.28.0",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.27.3",
+  "version": "2.28.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.27.3</version>
+    <version>2.28.0</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.js
+++ b/src/raygun.js
@@ -378,7 +378,7 @@ var raygunFactory = function (window, $, undefined) {
         if (type === 'pageView' && options.path) {
           _rum.virtualPageLoaded(options.path);
         } else if (type === 'customTiming') {
-          _rum.trackCustomTiming(options.name, options.duration, options.offset, parentResource);
+          _rum.trackCustomTiming(options.name, options.duration, options.offset || 0, parentResource);
         } else if (type === 'customTimings' && options.timings) {
           _rum.sendCustomTimings(options.timings, parentResource);
         }

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -158,7 +158,7 @@
           if (value.type && value.path) {
             rg.trackEvent(value.type, { path: value.path });
           } else if(value.type && value.name && value.duration) {
-            rg.trackEvent(value.type, { name: value.name, duration: value.duration, offset: value.offset });
+            rg.trackEvent(value.type, { name: value.name, duration: value.duration, offset: value.offset || 0 });
           } else if (value.type && value.timings) {
             rg.trackEvent(value.type, { timings: value.timings });
           }

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -287,6 +287,10 @@ var raygunRumFactory = function (window, $, Raygun) {
         version: self.version || 'Not supplied',
         tags: self.tags,
         device: window.raygunUserAgent,
+        client: {
+            name: "raygun4js",
+            version: '{{VERSION}}'
+        },
       }));
     }
 
@@ -602,8 +606,8 @@ var raygunRumFactory = function (window, $, Raygun) {
                   url: response.baseUrl,
                   statusCode: response.status,
                   timing: {
-                    du: maxFiveMinutes(response.duration).toFixed(2),
-                    a: offset.toFixed(2),
+                    du: maxFiveMinutes(response.duration).toFixed(2) || 0,
+                    a: offset.toFixed(2) || 0,
                     t: Timings.XHR
                   },
                 };
@@ -1255,6 +1259,10 @@ var raygunRumFactory = function (window, $, Raygun) {
         user: self.user,
         version: self.version || 'Not supplied',
         device: window.raygunUserAgent,
+        client: {
+            name: "raygun4js",
+            version: '{{VERSION}}'
+        },
         tags: self.tags,
         data: data,
       });

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -827,7 +827,7 @@ var raygunRumFactory = function (window, $, Raygun) {
       var data = {
         du: maxFiveMinutes(getTimingDuration(timing)).toFixed(2),
         t: getSecondaryTimingType(timing),
-        a: offset + timing.fetchStart,
+        a: offset + timing.fetchStart || timing.startTime || 0,
       };
 
       if (timing.domainLookupStart && timing.domainLookupStart > 0) {

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -1206,7 +1206,7 @@ var raygunRumFactory = function (window, $, Raygun) {
 
     function sanitizeNaNs(data) {
       for (var i in data) {
-        if (data[i] === "NaN" || data[i] === NaN) {
+        if (data[i] === "NaN" || Number.isNaN(data[i])) {
           data[i] = 0;
         }
       }

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -606,12 +606,11 @@ var raygunRumFactory = function (window, $, Raygun) {
                   url: response.baseUrl,
                   statusCode: response.status,
                   timing: {
-                    du: maxFiveMinutes(response.duration).toFixed(2) || 0,
+                    du: maxFiveMinutes(response.duration || 0).toFixed(2), //These are hacks to stop a potential situation where duration and/or offset are NaN, this is not a feature and needs to be fixed
                     a: (offset  || 0).toFixed(2),
                     t: Timings.XHR
                   },
                 };
-
                 collection.push(attachParentResource(payload, response.parentResource));
               }
             } while (responses.length > 0);

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -734,7 +734,7 @@ var raygunRumFactory = function (window, $, Raygun) {
         t: Timings.Page,
       };
 
-      data.a = timing.fetchStart;
+      data.a = timing.fetchStart || 0;
 
       if (timing.domainLookupStart && timing.domainLookupStart > 0) {
         data.b = timing.domainLookupStart - data.a;
@@ -827,7 +827,7 @@ var raygunRumFactory = function (window, $, Raygun) {
       var data = {
         du: maxFiveMinutes(getTimingDuration(timing)).toFixed(2),
         t: getSecondaryTimingType(timing),
-        a: offset + (timing.fetchStart || timing.startTime || 0),
+        a: (offset || 0) + (timing.fetchStart || timing.startTime || 0),
       };
 
       if (timing.domainLookupStart && timing.domainLookupStart > 0) {
@@ -1206,7 +1206,7 @@ var raygunRumFactory = function (window, $, Raygun) {
 
     function sanitizeNaNs(data) {
       for (var i in data) {
-        if (isNaN(data[i]) && typeof data[i] !== 'string') {
+        if (data[i] === "NaN") {
           data[i] = 0;
         }
       }

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -1206,7 +1206,7 @@ var raygunRumFactory = function (window, $, Raygun) {
 
     function sanitizeNaNs(data) {
       for (var i in data) {
-        if (data[i] === "NaN") {
+        if (data[i] === "NaN" || data[i] === NaN) {
           data[i] = 0;
         }
       }

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -607,7 +607,7 @@ var raygunRumFactory = function (window, $, Raygun) {
                   statusCode: response.status,
                   timing: {
                     du: maxFiveMinutes(response.duration).toFixed(2) || 0,
-                    a: offset.toFixed(2) || 0,
+                    a: (offset  || 0).toFixed(2),
                     t: Timings.XHR
                   },
                 };

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -827,7 +827,7 @@ var raygunRumFactory = function (window, $, Raygun) {
       var data = {
         du: maxFiveMinutes(getTimingDuration(timing)).toFixed(2),
         t: getSecondaryTimingType(timing),
-        a: offset + timing.fetchStart || timing.startTime || 0,
+        a: offset + (timing.fetchStart || timing.startTime || 0),
       };
 
       if (timing.domainLookupStart && timing.domainLookupStart > 0) {

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -287,7 +287,7 @@ var raygunRumFactory = function (window, $, Raygun) {
         version: self.version || 'Not supplied',
         tags: self.tags,
         device: window.raygunUserAgent,
-        client: {
+        client: { //This is incomplete, it does not add the client data to every payload that is sent
             name: "raygun4js",
             version: '{{VERSION}}'
         },
@@ -1258,7 +1258,7 @@ var raygunRumFactory = function (window, $, Raygun) {
         user: self.user,
         version: self.version || 'Not supplied',
         device: window.raygunUserAgent,
-        client: {
+        client: { //This is incomplete, it does not add the client data to every payload that is sent
             name: "raygun4js",
             version: '{{VERSION}}'
         },


### PR DESCRIPTION
This PR is being developed in conjunction with updates to the RUM worker that allows for client information to be sent, This includes the name and version of the library.

This PR also patches a number of situations that _could_ result in NaN values being sent to Raygun. The main areas changed are:
- Custom Timings and `AddMissingWRT` were accessing `offset` which is not always set. This now falls back to zero if no value exists
- Virtual Page Timings were accessing a browser API that is deprecated in some new browser updates, this now falls back to the new API
