### PR TITLE
Fix infinite recursive loop on UMD module init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unused normalize.css file
   
 -->
+## [2.27.3]
+
+### Changed
+
+- Fixes a rare condition with UMD where we assume rg4js is initialised but it is not, causing an infinite loop.
+
 
 
 ## [2.27.2]

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun4js",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun4js",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "SEE LICENSE IN https://github.com/MindscapeHQ/raygun4js/blob/master/LICENSE",
       "devDependencies": {
         "@wdio/cli": "^8.11.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>2.27.2</version>
+    <version>2.27.3</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -222,7 +222,7 @@
     window[window['RaygunObject']] = function() {
       return executor(arguments);
     };
-
+    window['RaygunInitialized'] = true;
     globalExecutorInstalled = true;
   };
 

--- a/src/umd.intro.js
+++ b/src/umd.intro.js
@@ -37,7 +37,7 @@
         wind['RaygunObject'] = 'rg4js';
         wind[wind['RaygunObject']] = wind[wind['RaygunObject']] || function() {
             if (wind && typeof wind['Raygun'] === 'undefined' ||
-                (typeof document === 'undefined' || document.readyState !== 'complete') || (!wind['RaygunInitialized']) {
+                (typeof document === 'undefined' || document.readyState !== 'complete') || (!wind['RaygunInitialized'])) {
                 // onload hasn't been called, cache the commands just like the snippet
                 (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
             } else {

--- a/src/umd.intro.js
+++ b/src/umd.intro.js
@@ -37,7 +37,7 @@
         wind['RaygunObject'] = 'rg4js';
         wind[wind['RaygunObject']] = wind[wind['RaygunObject']] || function() {
             if (wind && typeof wind['Raygun'] === 'undefined' ||
-                (typeof document === 'undefined' || document.readyState !== 'complete') || (wind['RaygunInitialized'] || false) === false) {
+                (typeof document === 'undefined' || document.readyState !== 'complete') || (!wind['RaygunInitialized']) {
                 // onload hasn't been called, cache the commands just like the snippet
                 (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
             } else {

--- a/src/umd.intro.js
+++ b/src/umd.intro.js
@@ -31,11 +31,6 @@
         windw['rg4js'].q = windw['rg4js'].q || [];
         windw['rg4js'].q.push({ e: err });
     };
-    let isWindowLoaded = false;
-
-    window.onload = function() {
-        isWindowLoaded = true;
-    };
     // Similar approach as the snippet, creates the rg4js proxy function, which is exported in umd.outro.js once the
     // script is executed, and later overwritten by the loader once it's finished
     (function(wind) {
@@ -47,8 +42,6 @@
                 (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
             } else {
                 // onload has been called and provider has executed, call the executor proxy function
-                var test = wind[wind['RaygunObject']];
-                console.log(test);
                 return wind[wind['RaygunObject']](arguments[0], arguments[1]);
             }
 

--- a/src/umd.intro.js
+++ b/src/umd.intro.js
@@ -1,9 +1,9 @@
 // https://github.com/umdjs/umd/blob/master/templates/returnExportsGlobal.js
 
-(function (root, factory) {
+(function(root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define('raygun4js', function () {
+        define('raygun4js', function() {
             return (root.Raygun = factory());
         });
     } else if (typeof module === 'object' && module.exports) {
@@ -15,34 +15,42 @@
         // Browser globals
         root.Raygun = factory();
     }
-}(this, function () {
+}(this, function() {
 
-  var windw = this || window || global;
-  var originalOnError = windw.onerror;
-  windw.onerror = function (msg, url, line, col, err) {
-    if (originalOnError) {
-      originalOnError(msg, url, line, col, err);
-    }
+    var windw = this || window || global;
+    var originalOnError = windw.onerror;
+    windw.onerror = function(msg, url, line, col, err) {
+        if (originalOnError) {
+            originalOnError(msg, url, line, col, err);
+        }
 
-    if (!err) {
-      err = new Error(msg);
-    }
+        if (!err) {
+            err = new Error(msg);
+        }
 
-    windw['rg4js'].q = windw['rg4js'].q || [];
-    windw['rg4js'].q.push({e: err});
-  };
+        windw['rg4js'].q = windw['rg4js'].q || [];
+        windw['rg4js'].q.push({ e: err });
+    };
+    let isWindowLoaded = false;
 
-  // Similar approach as the snippet, creates the rg4js proxy function, which is exported in umd.outro.js once the
-  // script is executed, and later overwritten by the loader once it's finished
-  (function(wind) { wind['RaygunObject'] = 'rg4js';
-  wind[wind['RaygunObject']] = wind[wind['RaygunObject']] || function() {
-      if (wind && typeof wind['Raygun'] === 'undefined' ||
-        (typeof document === 'undefined' || document.readyState !== 'complete')) {
-        // onload hasn't been called, cache the commands just like the snippet
-        (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
-      } else {
-        // onload has been called and provider has executed, call the executor proxy function
-        return wind[wind['RaygunObject']](arguments[0], arguments[1]);
-      }
-      
-  }})(windw);
+    window.onload = function() {
+        isWindowLoaded = true;
+    };
+    // Similar approach as the snippet, creates the rg4js proxy function, which is exported in umd.outro.js once the
+    // script is executed, and later overwritten by the loader once it's finished
+    (function(wind) {
+        wind['RaygunObject'] = 'rg4js';
+        wind[wind['RaygunObject']] = wind[wind['RaygunObject']] || function() {
+            if (wind && typeof wind['Raygun'] === 'undefined' ||
+                (typeof document === 'undefined' || document.readyState !== 'complete') || (wind['RaygunInitialized'] || false) === false) {
+                // onload hasn't been called, cache the commands just like the snippet
+                (wind[wind['RaygunObject']].o = wind[wind['RaygunObject']].o || []).push(arguments)
+            } else {
+                // onload has been called and provider has executed, call the executor proxy function
+                var test = wind[wind['RaygunObject']];
+                console.log(test);
+                return wind[wind['RaygunObject']](arguments[0], arguments[1]);
+            }
+
+        }
+    })(windw);

--- a/tests/fixtures/v2/UMDInfiniteLoop.html
+++ b/tests/fixtures/v2/UMDInfiniteLoop.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Raygun4JS with V2 API</title>
+    <script src="/fixtures/common/instrumentXHRs.js"></script>
+    <script>
+        document.onreadystatechange = () => {
+            if (document.readyState === "complete") {
+                rg4js('apiKey', 'abcdef=='); //this should trigger an infinite loop
+                rg4js('enableCrashReporting', false);
+                rg4js('enablePulse', true);
+            }
+        };
+    </script>
+    <script src="/dist/raygun.umd.min.js"></script>
+</head>
+
+<body>
+    <script type="text/javascript">
+
+        setTimeout(function () {
+            rg4js('trackEvent', {
+                type: 'customTiming',
+                name: 'timingName',
+                duration: 100,
+            });
+        }, 250);
+    </script>
+
+</body>
+
+</html>

--- a/tests/specs/v2/UMDInfiniteLoopTest.js
+++ b/tests/specs/v2/UMDInfiniteLoopTest.js
@@ -1,0 +1,35 @@
+var webdriverio = require('webdriverio');
+
+describe("UMD Infinite loop test", function() {
+    beforeEach(async function() {
+        /**
+         * Clears the session between tests to ensure
+         * that the sessionstart event is always fired 
+         */
+        await browser.reloadSession();
+    });
+
+    describe('test infinite loop is not caused', function() {
+        beforeEach(async function() {
+            await browser.url('http://localhost:4567/fixtures/v2/UMDInfiniteLoop.html');
+            await browser.pause(1000);
+        });
+
+        it('succesfully sends the event', async function() {
+            var customTimingData = await browser.execute(function() {
+                console.log(window.__requestPayloads)
+                return window.__requestPayloads[2];
+            });
+            console.log(customTimingData.eventData[0].data);
+            expect(JSON.parse(customTimingData.eventData[0].data)[0]).toEqual({
+                timing: {
+                    a: "0.00",
+                    du: "100.00",
+                    t: "t"
+                },
+                url: "timingName",
+                parentResource: { url: 'http://localhost:4567/fixtures/v2/UMDInfiniteLoop.html', type: 'p' }
+            });
+        });
+    });
+});

--- a/tests/specs/v2/UMDInfiniteLoopTest.js
+++ b/tests/specs/v2/UMDInfiniteLoopTest.js
@@ -1,5 +1,19 @@
 var webdriverio = require('webdriverio');
 
+
+
+
+/**
+* What does this test do?
+* When using the UMD module, if raygun events are fired (e.g. rg4js('send', ...)) 
+* before raygun is fully loaded they are stored in an object on the window.
+* When Raygun loads these are then processed.
+* However a bug was found where we were assuming raygun was loaded when 
+* `document.readyState === complete` but it is not loaded until slightly 
+* after when the `load` event is fired. This means that if a rayugn event 
+* is processed in this gap an infinite loop can be caused.
+* This test ensures graceful handling of this situation
+*/
 describe("UMD Infinite loop test", function() {
     beforeEach(async function() {
         /**


### PR DESCRIPTION
This PR is to solve an issue first surfaced in issue #473.

# The problem
We are assuming rg4js is loaded when `document.readyState` is marked as `complete`. However, this is not true, it's not loaded until after the `load` event has been triggered. According to the [spec](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) `complete` indicates that the `load` event is _about_ to fire. This leaves a small gap where if our code is executed between the document state being marked as complete and the `load` event firing, an infinite recursive loop is started that will hang the application. 

# The fix
The current fix I have in mind for this is to add a variable to the window that is set to true after we know for sure rg4js is initialized. The UMD initialization code will then wait for this rather than `document.readyState === 'complete'`