### PR TITLE
Fix typo in fetching XHR url for breadcrumbs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unused normalize.css file
   
 -->
+## [3.0.1]
+
+### Fixed
+- Fixed an typo raised by issue #508 that caused breadcrumb messages to be undefined
+
 ## [3.0.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/src/raygun.breadcrumbs.js
+++ b/src/raygun.breadcrumbs.js
@@ -475,7 +475,7 @@ window.raygunBreadcrumbsFactory = function(window, Raygun) {
       error.duration = error.duration + 'ms';
       self.recordBreadcrumb({
         type: 'request',
-        message: 'Failed request to ' + error.requestUrl,
+        message: 'Failed request to ' + error.requestURL,
         level: 'info',
         metadata: error,
       });


### PR DESCRIPTION
This bug fixes a typo in the breadcrumbs code when it try's to fetch the URL for a failed request.

This bug was raised in https://github.com/MindscapeHQ/raygun4js/issues/508.

https://github.com/MindscapeHQ/raygun4js/blob/fe73f53dd0af9dd8002025eb6fdd13238eb01de9/src/raygun.breadcrumbs.js#L478

`error.requestUrl` should be `error.requestURL`

# Before 
![image](https://github.com/MindscapeHQ/raygun4js/assets/48536946/7bdcb50d-9b93-40cc-b151-33e48881e087)

# After
![image](https://github.com/MindscapeHQ/raygun4js/assets/48536946/7461f610-1be6-408c-815a-adbbf9bf7e77)
