### PR TITLE
Limit Ping to be less frequent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 -->
 
+## [3.1.2]
+
+### Changed
+- Updated when ping happens so it only happens once, and when successful, it will store in sessionStorage and not ping again. This is to prevent multiple pings from happening on every page load.
+
 ## [3.1.1]
 
 ### Fixed

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>3.1.0</version>
+    <version>3.1.2</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.loader.js
+++ b/src/raygun.loader.js
@@ -30,7 +30,6 @@
     ping : {
         sessionStorageItem : 'raygun4js-successful-ping',
         sendPing : true,
-        pingIntervalId : -1,
         failedPings : 0
     },
   };
@@ -356,7 +355,6 @@
 
     if(metadata.ping.sendPing) {
       ping(); //call immediately
-      // metadata.ping.pingIntervalId = setInterval(ping, 1000 * 60 * 5); //5 minutes
     }
     window[window['RaygunObject']].q = errorQueue;
   };


### PR DESCRIPTION
This changes the way Ping happens by:

- Limiting ping to be once per session.
- Failure to ping will re-attempt at intervals of 10/20/40/80/120 seconds before stopping.
- Re-ping if `data` changes. This happens if the app sent `true` for rum and then changed to `false`, it would cause a re-ping to happens.