### PR TITLE
RUM Before Send Handler Includes XHR Request Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 -->
 
+## [3.1.3]
+
+### Changed
+- Updated RUM XHR events to include `requestDetails` for the `onBeforeSendRUM` handler. Request details include `url` (including query parameters), `method`, `body` and `responseBody`. These details are stripped from the payload before it's sent to Raygun's servers.
+
 ## [3.1.2]
 
 ### Changed

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun4js",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "homepage": "http://raygun.com",
   "authors": [
     "Mindscape <hello@raygun.com>"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "title": "Raygun4js",
   "description": "Raygun.com plugin for JavaScript",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "homepage": "https://github.com/MindscapeHQ/raygun4js",
   "author": {
     "name": "MindscapeHQ",

--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>raygun4js</id>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -742,7 +742,7 @@ var raygunRumFactory = function (window, $, Raygun) {
           url: xhrStatus.request.requestURL,
           method: xhrStatus.request.method,
           body: xhrStatus.request.body,
-          response: xhrStatus.response.body
+          responseBody: xhrStatus.response.body
         };
 
         log('found status for timing', timingData.statusCode);

--- a/src/raygun.rum/index.js
+++ b/src/raygun.rum/index.js
@@ -737,10 +737,13 @@ var raygunRumFactory = function (window, $, Raygun) {
 
         timingData.statusCode = xhrStatus.response.status;
         timingData.parentResource = xhrStatus.parentResource;
-        timingData.requestBody = xhrStatus.request.body;
-        timingData.requestUrl = xhrStatus.request.requestURL;
-        timingData.requestMethod = xhrStatus.request.method;
-        timingData.responseBody = xhrStatus.response.body;
+
+        timingData.requestDetails = {
+          url: xhrStatus.request.requestURL,
+          method: xhrStatus.request.method,
+          body: xhrStatus.request.body,
+          response: xhrStatus.response.body
+        };
 
         log('found status for timing', timingData.statusCode);
         if (this.xhrStatusMap[url].length === 0) {
@@ -988,7 +991,7 @@ var raygunRumFactory = function (window, $, Raygun) {
         if (!!payload.eventData) {
           for (var i = 0; i < payload.eventData.length; i++) {
             if (!!payload.eventData[i].data && typeof payload.eventData[i].data !== 'string') {
-              var strippedEventData = stripRequestAndResponseFromPayloadEventData(payload.eventData[i].data);
+              var strippedEventData = stripRequestDetailsFromPayloadEventData(payload.eventData[i].data);
               payload.eventData[i].data = JSON.stringify(strippedEventData);
             }
           }
@@ -1017,24 +1020,12 @@ var raygunRumFactory = function (window, $, Raygun) {
       }, (window.raygunUserAgentDataStatus === 1 ? 200 : 0));
     }
 
-    function stripRequestAndResponseFromPayloadEventData(payloadEventData){
+    function stripRequestDetailsFromPayloadEventData(payloadEventData){
       for (var i = 0 ; i < payloadEventData.length; i++) {
         var eventDataItem = payloadEventData[i];
 
-        if (eventDataItem.requestUrl) {
-          delete eventDataItem.requestUrl;
-        }
-
-        if (eventDataItem.requestBody) {
-          delete eventDataItem.requestBody;
-        }
-
-        if (eventDataItem.requestMethod) {
-          delete eventDataItem.requestMethod;
-        }
-
-        if (eventDataItem.responseBody) {
-          delete eventDataItem.responseBody;
+        if (eventDataItem.requestDetails) {
+          delete eventDataItem.requestDetails;
         }
       }
 


### PR DESCRIPTION
This PR updates the details associated with RUM XHR events to include the original request details. These details are under a new `requestDetails` property and they include `url` (with query parameters), `method`, `body` and `responseBody`.  Request details are only present in the paylod until the `onBeforeSendRUM` handler has been called, after this they're stripped from the payload, so as to not be sent to Raygun's servers. The purpose of this change is to support hydrating certain request details into XHR events, should users wish to do this. As an example, we could now swap out the `url` of the xhr event , to be the one from `requestDetails`, so that it includes query parameters in Raygun.