### PR TITLE
fix: #541 package nuspec warnings

### DIFF
--- a/raygun4js.nuspec
+++ b/raygun4js.nuspec
@@ -6,13 +6,14 @@
     <title>Raygun4js</title>
     <authors>Raygun Limited</authors>
     <owners>Raygun Limited</owners>
-    <licenseUrl>https://raw2.github.com/MindscapeHQ/raygun4js/master/LICENSE</licenseUrl>
+    <license type="file">LICENSE</license>
     <projectUrl>http://raygun.com/raygun-providers/javascript</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Official Raygun JavaScript module - automatic client-side error tracking and Real User Monitoring for your web project</summary>
     <description>Raygun4js is a tiny library that you can easily add to your website or web application, which will then let your site automatically transmit all Errors to your Raygun.com dashboard, where you can see the stack trace, environment data, custom data and more. Installation is painless, and configuring your site to transmit errors takes just a couple of minutes.</description>
     <language>en-US</language>
     <tags>raygun error tracking reporting logging monitoring</tags>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
@@ -22,5 +23,7 @@
     <file src="dist\raygun.vanilla.js" target="content\scripts\raygun.vanilla.js" />
     <file src="dist\raygun.vanilla.min.js" target="content\scripts\raygun.vanilla.min.js" />
     <file src="dist\raygun.vanilla.min.js.map" target="content\scripts\raygun.vanilla.min.js.map" />
+    <file src="LICENSE" target="LICENSE" />
+    <file src="README.md" target="README.md" />
   </files>
 </package>


### PR DESCRIPTION
This PR fixes the nuspec warnings.

Output of nuget tool:

```
mono ~/bin/nuget.exe pack raygun4js.nuspec        
Attempting to build package from 'raygun4js.nuspec'.
Successfully created package '/[redacted]/raygun4js/raygun4js.3.1.4.nupkg'.
```

Closes #541 